### PR TITLE
Fix: add  to login reset password page

### DIFF
--- a/src/login/kcContext/KcContext.ts
+++ b/src/login/kcContext/KcContext.ts
@@ -183,6 +183,9 @@ export declare namespace KcContext {
         realm: {
             loginWithEmailAllowed: boolean;
         };
+        url: {
+            loginResetCredentialsUrl: string;
+        }
     };
 
     export type LoginVerifyEmail = Common & {

--- a/src/login/kcContext/kcContextMocks.ts
+++ b/src/login/kcContext/kcContextMocks.ts
@@ -329,7 +329,8 @@ export const kcContextMocks: KcContext[] = [
         "realm": {
             ...kcContextCommonMock.realm,
             "loginWithEmailAllowed": false
-        }
+        },
+        url: loginUrl
     }),
     id<KcContext.LoginVerifyEmail>({
         ...kcContextCommonMock,


### PR DESCRIPTION
This PR includes the credential reset url among the kcContext types.

Closes #278 