### PR TITLE
feat: add keycloakify json schema

### DIFF
--- a/keycloakify-json-schema.json
+++ b/keycloakify-json-schema.json
@@ -1,0 +1,91 @@
+{
+    "allOf": [
+        {
+            "$ref": "https://json.schemastore.org/package.json"
+        },
+        {
+            "$ref": "keycloakifyPackageJsonSchema"
+        }
+    ],
+    "$ref": "#/definitions/keycloakifyPackageJsonSchema",
+    "definitions": {
+        "keycloakifyPackageJsonSchema": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "version": {
+                    "type": "string"
+                },
+                "homepage": {
+                    "type": "string"
+                },
+                "keycloakify": {
+                    "type": "object",
+                    "properties": {
+                        "extraPages": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "extraLoginPages": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "extraAccountPages": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "extraThemeProperties": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "areAppAndKeycloakServerSharingSameDomain": {
+                            "type": "boolean"
+                        },
+                        "artifactId": {
+                            "type": "string"
+                        },
+                        "groupId": {
+                            "type": "string"
+                        },
+                        "bundler": {
+                            "type": "string",
+                            "enum": ["mvn", "keycloakify", "none"]
+                        },
+                        "keycloakVersionDefaultAssets": {
+                            "type": "string"
+                        },
+                        "reactAppBuildDirPath": {
+                            "type": "string"
+                        },
+                        "keycloakifyBuildDirPath": {
+                            "type": "string"
+                        },
+                        "customUserAttributes": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "themeName": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            },
+            "required": ["name", "version"],
+            "additionalProperties": false
+        }
+    },
+    "$schema": "http://json-schema.org/draft-07/schema#"
+}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
         "prepare": "yarn generate-i18n-messages",
         "build": "rimraf dist/ && tsc -p src/bin && tsc -p src/tsconfig.json && tsc-alias -p src/tsconfig.json && yarn grant-exec-perms && yarn copy-files dist/",
         "build:watch": "tsc -p src/tsconfig.json && (concurrently \"tsc -p src/tsconfig.json -w\" \"tsc-alias -p src/tsconfig.json\")",
+        "generate:json-schema": "ts-node scripts/generate-json-schema.ts",
         "grant-exec-perms": "node dist/bin/tools/grant-exec-perms.js",
         "copy-files": "copyfiles -u 1 src/**/*.ftl",
         "test": "yarn test:types && vitest run",
@@ -82,7 +83,8 @@
         "ts-node": "^10.9.1",
         "tsc-alias": "^1.8.3",
         "typescript": "^5.0.1-rc",
-        "vitest": "^0.29.8"
+        "vitest": "^0.29.8",
+        "zod-to-json-schema": "^3.20.4"
     },
     "dependencies": {
         "@octokit/rest": "^18.12.0",

--- a/scripts/generate-json-schema.ts
+++ b/scripts/generate-json-schema.ts
@@ -1,0 +1,14 @@
+import fs from "fs";
+import path from "path";
+import zodToJsonSchema from "zod-to-json-schema";
+import { zParsedPackageJson } from "../src/bin/keycloakify/parsedPackageJson";
+
+const jsonSchemaName = "keycloakifyPackageJsonSchema";
+const jsonSchema = zodToJsonSchema(zParsedPackageJson, jsonSchemaName);
+
+const baseProperties = {
+    // merges package.json schema with keycloakify properties
+    "allOf": [{ "$ref": "https://json.schemastore.org/package.json" }, { "$ref": jsonSchemaName }]
+};
+
+fs.writeFileSync(path.join(process.cwd(), "keycloakify-json-schema.json"), JSON.stringify({ ...baseProperties, ...jsonSchema }, null, 2));

--- a/src/bin/keycloakify/parsedPackageJson.ts
+++ b/src/bin/keycloakify/parsedPackageJson.ts
@@ -28,7 +28,7 @@ export type ParsedPackageJson = {
     };
 };
 
-const zParsedPackageJson = z.object({
+export const zParsedPackageJson = z.object({
     "name": z.string(),
     "version": z.string(),
     "homepage": z.string().optional(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -3242,6 +3242,11 @@ yocto-queue@^1.0.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.0.0.tgz#7f816433fb2cbc511ec8bf7d263c3b58a1a3c251"
   integrity sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==
 
+zod-to-json-schema@^3.20.4:
+  version "3.20.4"
+  resolved "https://registry.yarnpkg.com/zod-to-json-schema/-/zod-to-json-schema-3.20.4.tgz#155f687c5a059fdc0f1bb3ff32d6e9200036b6f4"
+  integrity sha512-Un9+kInJ2Zt63n6Z7mLqBifzzPcOyX+b+Exuzf7L1+xqck9Q2EPByyTRduV3kmSPaXaRer1JCsucubpgL1fipg==
+
 zod@^3.17.10:
   version "3.21.4"
   resolved "https://registry.yarnpkg.com/zod/-/zod-3.21.4.tgz#10882231d992519f0a10b5dd58a38c9dabbb64db"


### PR DESCRIPTION
# Description
Uses [zod-to-json-schema](https://www.npmjs.com/package/zod-to-json-schema) to add a script which generates a json schema for keycloakify apps to support intellisense. Ex:

![image](https://user-images.githubusercontent.com/10997562/230197799-993bba2b-31c2-429c-9172-968ff682142b.png)

# Example Usage
```
// package.json
{
    "$schema": "https://raw.githubusercontent.com/keycloakify/keycloakify/4a7dd64982711f388a25ffcb09c8ca8fa91d0f00/keycloakify-json-schema.json",
    "name": "keycloakify-starter"
    ....

```

# Open Questions

~If descriptions for fields are important, how do they get injected?~

Answered: Zod already has [describe](https://zod.dev/?id=describe) which `zod-to-json-schema` supports