### PR TITLE
fix: fix broken jar

### DIFF
--- a/src/bin/tools/jar.ts
+++ b/src/bin/tools/jar.ts
@@ -48,8 +48,12 @@ export async function jarStream({ groupId, artifactId, version, asyncPathGenerat
     for await (const entry of asyncPathGeneratorFn()) {
         if ("buffer" in entry) {
             zipFile.addBuffer(entry.buffer, entry.zipPath);
-        } else if ("fsPath" in entry && !entry.fsPath.endsWith(sep)) {
-            zipFile.addFile(entry.fsPath, entry.zipPath);
+        } else if ("fsPath" in entry) {
+            if (entry.fsPath.endsWith(sep)) {
+                zipFile.addEmptyDirectory(entry.zipPath);
+            } else {
+                zipFile.addFile(entry.fsPath, entry.zipPath);
+            }
         }
     }
 


### PR DESCRIPTION
Many tools will handle zipfiles which lack directory entries just fine, others will not. Looks like the JDKs JAR libs are not handling  it well. This commit will make sure to create folder entries.

Should fix #330 and #331; Probably also #336, though I'd need some confirmation there since the reproduction path seems rather elaborate