### PR TITLE
Parse datetime objects as iso strings

### DIFF
--- a/src/bin/keycloakify/generateFtl/ftl_object_to_js_code_declaring_an_object.ftl
+++ b/src/bin/keycloakify/generateFtl/ftl_object_to_js_code_declaring_an_object.ftl
@@ -337,6 +337,17 @@
 
         </#if>
 
+        <#local isDate = "">
+        <#attempt>
+            <#local isDate = object?is_date_like>
+        <#recover>
+            <#return "ABORT: Can't test if it's a date">
+        </#attempt>
+
+        <#if isDate>
+            <#return '"' + object?datetime?iso_utc + '"'>
+        </#if>
+
         <#attempt>
             <#return '"' + object?js_string + '"'>;
         <#recover>


### PR DESCRIPTION
This parses datetime objects as iso strings.

This is needed for example on the `sessions.ftl` page where you want to render the `started`, `lastAccess` and `expires` values.