### PR TITLE
Change node.js 16.6.0 dependency that Array.prototype.at

### DIFF
--- a/src/bin/tools/trimIndent.ts
+++ b/src/bin/tools/trimIndent.ts
@@ -9,7 +9,7 @@ function populateTemplate(strings: TemplateStringsArray, ...args: unknown[]) {
         if (strings[i]) {
             chunks.push(strings[i]);
             // remember last indent of the string portion
-            lastStringLineLength = strings[i].split("\n").at(-1)?.length ?? 0;
+            lastStringLineLength = strings[i].split("\n").slice(-1)[0]?.length ?? 0;
         }
         if (args[i]) {
             // if the interpolation value has newlines, indent the interpolation values


### PR DESCRIPTION
My node.js environment is v14.19.1. Because of that i get this error:

```
TypeError: strings[i].split(...).at is not a function
at populateTemplate (/path/foo/keycloakify-starter/node_modules/keycloakify/bin/tools/trimIndent.js:46:75)
```