### PR TITLE
Bugfix/js runtime errors

### DIFF
--- a/src/bin/keycloakify/generateFtl/ftl_object_to_js_code_declaring_an_object.ftl
+++ b/src/bin/keycloakify/generateFtl/ftl_object_to_js_code_declaring_an_object.ftl
@@ -61,6 +61,7 @@
                                 return <#if messagesPerField.existsError('${fieldName}')>true<#else>false</#if>;
                             </#if>
                         <#recover>
+                          return false;
                         </#attempt>
                     }
                 </#list>
@@ -84,6 +85,7 @@
                                 </#if>
                             </#if>
                         <#recover>
+                          return '';
                         </#attempt>
                     }
                 </#list>
@@ -103,6 +105,7 @@
                                 return <#if messagesPerField.exists('${fieldName}')>true<#else>false</#if>;
                             </#if>
                         <#recover>
+                          return false;
                         </#attempt>
                     }
                 </#list>

--- a/src/bin/keycloakify/generateFtl/ftl_object_to_js_code_declaring_an_object.ftl
+++ b/src/bin/keycloakify/generateFtl/ftl_object_to_js_code_declaring_an_object.ftl
@@ -41,6 +41,7 @@
                                 return <#if messagesPerField.existsError('${fieldName}')>x<#else>undefined</#if>;
                             </#if>
                         <#recover>
+                          return undefined;
                         </#attempt>
                     }
                 </#list>


### PR DESCRIPTION
Hello,

First of all thanks for the great package!

When I ran this project in a production environment, it failed for a few pages, such as registration and update password - white screen was shown and there was a JavaScript error in the console. I located the error to be in the `printIfExists` function. In my case, the function had if statements with empty bodies, so no matter what was passed in, the error was thrown:

```js
"printIfExists": function (fieldName, x) {
    if(fieldName === "global" ){
    }
    if(fieldName === "userLabel" ){
    }
    if(fieldName === "username" ){
    }

    /* ... and so forth ... */
                 
    throw new Error("There is no " + fieldName + " field");
},
```

I noticed that inside the ftl file, there was an attempt / recover block, and in my case (I am using Keycloak 11.0.2), the recover block was being triggered, but that recover block did not generate any code, which led to empty if statements.

I fixed this issue by adding a return statement in the recover block. I am not sure if this is the right way to do it, could you advise?