### PR TITLE
v6: Use message string for the supported applications

### DIFF
--- a/src/lib/pages/LoginConfigTotp.tsx
+++ b/src/lib/pages/LoginConfigTotp.tsx
@@ -29,7 +29,7 @@ export default function LoginConfigTotp(props: PageProps<Extract<KcContextBase, 
 
                             <ul id="kc-totp-supported-apps">
                                 {totp.policy.supportedApplications.map(app => (
-                                    <li>{ msg(app as MessageKeyBase) == undefined? app : msg(app as MessageKeyBase) }</li>
+                                    <li>{msg(app as MessageKeyBase)}</li>
                                 ))}
                             </ul>
                         </li>

--- a/src/lib/pages/LoginConfigTotp.tsx
+++ b/src/lib/pages/LoginConfigTotp.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { clsx } from "../tools/clsx";
 import type { PageProps } from "../KcProps";
 import type { KcContextBase } from "../getKcContext";
-import type { I18nBase } from "../i18n";
+import type { I18nBase, MessageKeyBase } from "../i18n";
 
 export default function LoginConfigTotp(props: PageProps<Extract<KcContextBase, { pageId: "login-config-totp.ftl" }>, I18nBase>) {
     const { kcContext, i18n, doFetchDefaultThemeResources = true, Template, ...kcProps } = props;
@@ -29,7 +29,7 @@ export default function LoginConfigTotp(props: PageProps<Extract<KcContextBase, 
 
                             <ul id="kc-totp-supported-apps">
                                 {totp.policy.supportedApplications.map(app => (
-                                    <li>{app}</li>
+                                    <li>{ msg(app as MessageKeyBase) == undefined? app : msg(app as MessageKeyBase) }</li>
                                 ))}
                             </ul>
                         </li>


### PR DESCRIPTION
Apparently, the totp.policy.supportedApplications array returns the message keys for the apps, they need to be replaced by actual translation. To keep the default behavior before this PR, if the translation is not available, it will default to the message key on screen.