### PR TITLE
Handle CSS with multiple `url`s

### DIFF
--- a/src/bin/keycloakify/replacers/replaceImportsInCssCode.ts
+++ b/src/bin/keycloakify/replacers/replaceImportsInCssCode.ts
@@ -16,7 +16,7 @@ export function replaceImportsInCssCode(params: { cssCode: string }): {
 
     const cssGlobalsToDefine: Record<string, string> = {};
 
-    new Set(cssCode.match(/url\(["']?\/[^/][^)"']+["']?\)[^;}]*/g) ?? []).forEach(
+    new Set(cssCode.match(/url\(["']?\/[^/][^)"']+["']?\)[^;}]*?/g) ?? []).forEach(
         match => (cssGlobalsToDefine["url" + crypto.createHash("sha256").update(match).digest("hex").substring(0, 15)] = match)
     );
 


### PR DESCRIPTION
The theme build process breaks CSS with properties that have multiple URL entries, like `background-image`:

```css
body {
    background: image-set(url(/static/media/background@2x.94c864eb5ec048a3ccb1.jpg) 2x type("image/jpeg"), url(/static/media/background@2x.0ffa1919b145ac4f7e0d.webp) 2x type("image/webp"), url(/static/media/background.af4f4bf32ef997b6fd64.jpg) type("image/jpeg"), url(/static/media/background.d31202be8f25e0a757b2.webp) type("image/webp")) no-repeat 50%;
    background-size: cover;
}
```

This is turned into:

```css
body {
    background: image-set(var(--urlcf7fa946431c683);
    background-size: cover;
}
```

and

```html
<style>
:root {
    --urlcf7fa946431c683: url(${url.resourcesPath}/build/static/media/background@2x.94c864eb5ec048a3ccb1.jpg) 2x type("image/jpeg"),url(${url.resourcesPath}/build/static/media/background@2x.0ffa1919b145ac4f7e0d.webp) 2x type("image/webp"),url(${url.resourcesPath}/build/static/media/background.af4f4bf32ef997b6fd64.jpg) type("image/jpeg"),url(${url.resourcesPath}/build/static/media/background.d31202be8f25e0a757b2.webp) type("image/webp")) no-repeat 50%;
}
</style>
```

This is because of the greedy `*` in the CSS URL regex that matches until the last URL value:

```js
new Set(cssCode.match(/url\(["']?\/[^/][^)"']+["']?\)[^;}]*/g) ?? []).forEach(
//                                                        ^- here
```

This PR fixes this issue.