### PR TITLE
Fixes #473: Set document title using the "loginTitle" translation

### DIFF
--- a/src/login/Template.tsx
+++ b/src/login/Template.tsx
@@ -45,6 +45,8 @@ export default function Template(props: TemplateProps<KcContext, I18n>) {
         return null;
     }
 
+    document.title = i18n.msgStr("loginTitle", kcContext.realm.displayName);
+
     return (
         <div className={getClassName("kcLoginClass")}>
             <div id="kc-header" className={getClassName("kcHeaderClass")}>


### PR DESCRIPTION
Since realm can't be changed without the page being refreshed I think this is a suitable solution.

The starter kit projects needs to adapt this change for people who is using that to benefit from this change.