### PR TITLE
refactor: point the import statement to keycloakify instead of internal

### DIFF
--- a/src/login/pages/LoginDeviceVerifyUserCode.tsx
+++ b/src/login/pages/LoginDeviceVerifyUserCode.tsx
@@ -1,7 +1,7 @@
 import { clsx } from "keycloakify/tools/clsx";
 import { I18n } from "../i18n";
 import { KcContext } from "../kcContext";
-import { useGetClassName } from "../lib/useGetClassName";
+import { useGetClassName } from "keycloakify/login/lib/useGetClassName";
 import { PageProps } from "./PageProps";
 
 export default function LoginOauthGrant(props: PageProps<Extract<KcContext, { pageId: "login-oauth2-device-verify-user-code.ftl" }>, I18n>) {


### PR DESCRIPTION
align import statement with other page templates