### PR TITLE
Update theme parent reference to keycloak.v2 due to removal

### DIFF
--- a/src/bin/keycloakify/generateTheme/generateTheme.ts
+++ b/src/bin/keycloakify/generateTheme/generateTheme.ts
@@ -231,7 +231,7 @@ export async function generateTheme(params: {
                     if (pathBasename(filePath) === "theme.properties") {
                         return {
                             "modifiedSourceCode": Buffer.from(
-                                sourceCode.toString("utf8").replace(`parent=${accountV1ThemeName}`, "parent=keycloak"),
+                                sourceCode.toString("utf8").replace(`parent=${accountV1ThemeName}`, "parent=keycloak.v2"),
                                 "utf8"
                             )
                         };


### PR DESCRIPTION
## Update Theme Parent Reference to keycloak.v2

This pull request updates the parent theme reference within the `theme.properties` file from `keycloak` to `keycloak.v2`. This change is necessary due to the removal of the `keycloak` theme for accounts, ensuring our theme properly inherits from the current `keycloak.v2` theme.

### Background
The `keycloak` theme for accounts is no longer available (keycloak version 23), necessitating this update to maintain compatibility and leverage the latest theme improvements provided by Keycloak. The `keycloak.v2` theme offers updated styles and components that are essential for a coherent user experience across our Keycloak-based authentication flows.

### Changes
- Modified the theme parent reference in the theme generation logic (`generateTheme.ts`) to use `keycloak.v2` instead of `keycloak`.

### Implications
This update ensures that our custom theme remains compatible with the latest Keycloak theme standards and benefits from the enhancements and bug fixes in `keycloak.v2`.

For more information on Keycloak base themes, please refer to the [Keycloak themes source code](https://github.com/keycloak/keycloak/tree/main/themes/src/main/resources/theme).

### Request for Review
I invite the team to review the proposed changes to ensure they meet our requirements for theme compatibility and style coherence. Your insights and feedback are highly valued.
