### PR TITLE
Allow docker start script to work with podman

### DIFF
--- a/src/bin/start-keycloak/start-keycloak.ts
+++ b/src/bin/start-keycloak/start-keycloak.ts
@@ -37,15 +37,17 @@ export type CliCommandOptions = CliCommandOptions_common & {
 
 export async function command(params: { cliCommandOptions: CliCommandOptions }) {
     exit_if_docker_not_installed: {
-        let commandOutput: Buffer | undefined = undefined;
+        let commandOutput: string | undefined = undefined;
 
         try {
-            commandOutput = child_process.execSync("docker --version", {
-                stdio: ["ignore", "pipe", "ignore"]
-            });
+            commandOutput = child_process
+                .execSync("docker --version", {
+                    stdio: ["ignore", "pipe", "ignore"]
+                })
+                ?.toString("utf8");
         } catch {}
 
-        if (commandOutput?.toString("utf8").includes("Docker")) {
+        if (commandOutput?.includes("Docker") || commandOutput?.includes("podman")) {
             break exit_if_docker_not_installed;
         }
 


### PR DESCRIPTION
Hey there,

I noticed that the start-keycloak script refuses to run when the output of `docker --version` does not contain the word "Docker", which is the case when using Podman as a drop-in replacement for Docker.

~~This PR changes the script to only check if the command `docker --version` completes successfully instead of relying on a certain string in the output.~~

This PR changes the script to allow "podman" in the output of `docker --version` as well