### PR TITLE
:sparkles: Added `generate-resources` CLI command

### DIFF
--- a/src/bin/keycloakify/keycloakifyext.ts
+++ b/src/bin/keycloakify/keycloakifyext.ts
@@ -1,0 +1,73 @@
+import type { CliCommandOptions } from "../main";
+import { getBuildContext } from "../shared/buildContext";
+import chalk from "chalk";
+import { readThisNpmPackageVersion } from "../tools/readThisNpmPackageVersion";
+import { join as pathJoin, relative as pathRelative, sep as pathSep } from "path";
+import fs from "fs";
+import child_process from "child_process";
+import { VITE_PLUGIN_SUB_SCRIPTS_ENV_NAMES } from "../shared/constants";
+import { generateResources } from "./generateResources";
+
+export async function command(params: { cliCommandOptions: CliCommandOptions }) {
+    const { cliCommandOptions } = params;
+    const buildContext = getBuildContext({ cliCommandOptions });
+
+    console.log(
+        [
+            chalk.cyan(`keycloakify v${readThisNpmPackageVersion()}`),
+            chalk.green(
+                `Building the keycloak theme in .${pathSep}${pathRelative(
+                    process.cwd(),
+                    buildContext.keycloakifyBuildDirPath
+                )} ...`
+            )
+        ].join(" ")
+    );
+
+    const startTime = Date.now();
+
+    {
+        if (!fs.existsSync(buildContext.keycloakifyBuildDirPath)) {
+            fs.mkdirSync(buildContext.keycloakifyBuildDirPath, {
+                recursive: true
+            });
+        }
+
+        fs.writeFileSync(
+            pathJoin(buildContext.keycloakifyBuildDirPath, ".gitignore"),
+            Buffer.from("*", "utf8")
+        );
+    }
+
+    const resourcesDirPath = pathJoin(buildContext.keycloakifyBuildDirPath, "resources");
+
+    await generateResources({
+        resourcesDirPath,
+        buildContext
+    });
+
+    run_post_build_script: {
+        if (buildContext.bundler !== "vite") {
+            break run_post_build_script;
+        }
+
+        child_process.execSync("npx vite", {
+            cwd: buildContext.projectDirPath,
+            env: {
+                ...process.env,
+                [VITE_PLUGIN_SUB_SCRIPTS_ENV_NAMES.RUN_POST_BUILD_SCRIPT]: JSON.stringify(
+                    {
+                        resourcesDirPath,
+                        buildContext
+                    }
+                )
+            }
+        });
+    }
+
+    console.log(
+        chalk.green(
+            `✓ keycloak theme built in ${((Date.now() - startTime) / 1000).toFixed(2)}s`
+        )
+    );
+}

--- a/src/bin/main.ts
+++ b/src/bin/main.ts
@@ -76,6 +76,15 @@ program
         }
     });
 
+program.command({ name: "generate-resources", description: "Generate resources" }).task({
+    skip,
+    handler: async cliCommandOptions => {
+        const { command } = await import("./keycloakify/keycloakifyext");
+
+        await command({ cliCommandOptions });
+    }
+});
+
 program
     .command<{
         port: number | undefined;


### PR DESCRIPTION
This is a feature request I believe.
I have a bigger repo of extensions for keycloak, but written in kotlin and instead of maven, gradle is the build system. I'd like to add themes to my repo, and keycloakify seems to be a good fit. However it would feel strange to use maven next to gradle through keycloakify in said repo.
I've figured that if I just make the `keycloakify` cli to just generate the resources, I can create my own gradle script to pick those up and build a `jar` file, instead of relying on `keycloakify` cli to do that for me through maven.

Just for reference my gradle script looks like this:

```kotlin
import java.nio.file.Files
import kotlin.io.path.Path
import org.siouan.frontendgradleplugin.infrastructure.gradle.InstallFrontendTask

plugins {
    kotlin("jvm") version "2.0.20"
    id("com.gradleup.shadow") version "8.3.0"
    id("org.siouan.frontend-jdk21") version "8.1.0"
    id("java")
}

group = "org.pushrbx"
version = "1.0-SNAPSHOT"
val jarBaseName = "org.pushrbx.keycloak-themes"

repositories {
    mavenCentral()
}

dependencies {
    testImplementation(kotlin("test"))
    implementation("org.keycloak", "keycloak-client-registration-api", "25.0.4")
    implementation("dev.jcputney", "keycloak-theme-additional-info-extension", "1.1.5")
    implementation("io.phasetwo.keycloak", "keycloak-account-v1", "0.6")
}

tasks.test {
    useJUnitPlatform()
}

kotlin {
    jvmToolchain(17)
}

java {
    toolchain {
        languageVersion.set(JavaLanguageVersion.of(17))
    }
}

tasks.withType<JavaCompile> {
    options.release.set(17) // Ensure Java compatibility with 17
}

frontend {
    nodeVersion.set("22.6.0")
    nodeInstallDirectory.set(project.layout.projectDirectory.dir(".node"))
    installScript.set("install")
    assembleScript.set("run build")
    cleanScript.set("run clean")
}

tasks {
    val themeFiles by named<InstallFrontendTask>("installFrontend") {
        val ciPlatformPresent = providers.environmentVariable("CI").isPresent()
        val lockFilePath = "${projectDir}/package-lock.json"
        val retainedMetadataFileNames: Set<String>
        if (ciPlatformPresent) {
            retainedMetadataFileNames = setOf(lockFilePath)
        } else {
            val acceptableMetadataFileNames = listOf(lockFilePath, "${projectDir}/yarn.lock")
            retainedMetadataFileNames = mutableSetOf("${projectDir}/package.json")
            for (acceptableMetadataFileName in acceptableMetadataFileNames) {
                if (Files.exists(Path(acceptableMetadataFileName))) {
                    retainedMetadataFileNames.add(acceptableMetadataFileName)
                    break
                }
            }
            outputs.file(lockFilePath).withPropertyName("lockFile")
        }

        inputs.files(retainedMetadataFileNames).withPropertyName("metadataFiles")
        outputs.dir("${projectDir}/node_modules").withPropertyName("nodeModulesDirectory")
    }

    build {
        dependsOn(themeFiles)
    }

    assemble {
        dependsOn(themeFiles)
    }

    jar {
        archiveBaseName = jarBaseName
        manifest {
            attributes["Build-Jdk-Spec"] = "21"
        }
    }

    shadowJar {
        dependencies {
            include(dependency("dev.jcputney:keycloak-theme-additional-info-extension:1.1.5"))
            include(dependency("io.phasetwo.keycloak:keycloak-account-v1:0.6"))
        }
        archiveBaseName = jarBaseName
        dependsOn(build)
    }
}
```

`siouan.frontendgradleplugin` plugin installs nodejs, and installs the packages, then runs scripts from the package.json during a gradle build.
`shadowjar` is the equivalent of `shade` in the `pom.xml` generated by keycloakify.

In order to let gradle know about the generated resources by keycloakify, my build script in `package.json` calls this new command and copies the generated files:

```
tsc && vite build && keycloakify generate-resources && cp -r ./dist_keycloak/resources/theme ./src/main/resources/
```

     
This would make `keycloakify` compatible with any other build system outside maven.
