### PR TITLE
fix: context filter smtp config syntax error

### DIFF
--- a/src/bin/keycloakify/generateFtl/ftl_object_to_js_code_declaring_an_object.ftl
+++ b/src/bin/keycloakify/generateFtl/ftl_object_to_js_code_declaring_an_object.ftl
@@ -176,7 +176,7 @@ ${ftl_object_to_js_code_declaring_an_object(.data_model, [])?no_esc};
                         are_same_path(path, ["realm"])
                     ) || (
                         "smtpConfig" == key &&
-                        are_same_path(path, ["realm"]) &&
+                        are_same_path(path, ["realm"])
                     ) || (
                         "error.ftl" == pageId &&
                         are_same_path(path, ["realm"]) &&


### PR DESCRIPTION
remove trailing &&