### PR TITLE
fix: added parameter type for story context on register page

### DIFF
--- a/stories/login/pages/Register.stories.tsx
+++ b/stories/login/pages/Register.stories.tsx
@@ -240,8 +240,8 @@ export const WithFieldErrors: Story = {
                     }
                 },
                 messagesPerField: {
-                    existsError: fieldName => ["username", "email"].includes(fieldName),
-                    get: fieldName => {
+                    existsError: (fieldName: string) => ["username", "email"].includes(fieldName),
+                    get: (fieldName: string) => {
                         if (fieldName === "username") return "Username is required.";
                         if (fieldName === "email") return "Invalid email format.";
                     }


### PR DESCRIPTION
simply added in the missing parameter type that was throwing build errors on the register.stories.tsx file.