### PR TITLE
Allow skipping rm Keycloakify dev resource

### DIFF
--- a/src/bin/shared/buildContext.ts
+++ b/src/bin/shared/buildContext.ts
@@ -93,6 +93,7 @@ export type BuildOptions = {
         realmJsonFilePath?: string;
         port?: number;
     };
+    skipRemoveDevResources?: boolean;
 } & BuildOptions.AccountThemeImplAndKeycloakVersionTargets;
 
 export namespace BuildOptions {

--- a/src/vite-plugin/vite-plugin.ts
+++ b/src/vite-plugin/vite-plugin.ts
@@ -199,16 +199,18 @@ export function keycloakify(params: keycloakify.Params) {
 
             assert(buildDirPath !== undefined);
 
-            await rm(
-                pathJoin(
-                    buildDirPath,
-                    WELL_KNOWN_DIRECTORY_BASE_NAME.KEYCLOAKIFY_DEV_RESOURCES
-                ),
-                {
-                    recursive: true,
-                    force: true
-                }
-            );
+            if (!buildOptions?.skipRemoveDevResources) {
+                await rm(
+                    pathJoin(
+                        buildDirPath,
+                        WELL_KNOWN_DIRECTORY_BASE_NAME.KEYCLOAKIFY_DEV_RESOURCES
+                    ),
+                    {
+                        recursive: true,
+                        force: true
+                    }
+                );
+            }
         }
     } satisfies Plugin;
 


### PR DESCRIPTION
Similar to https://github.com/keycloakify/keycloakify/pull/647 but taking a **_shortcut_** to allow skipping removal of Keycloakify's dev resources. The reason for this is because we need to the raw dev resource to update the static files (js,css) into Keycloak, instead of packing into a `.jar.` and then upload.