### PR TITLE
Removed Error Message from Terms and Conditions Page

### DIFF
--- a/stories/login/pages/Terms.stories.tsx
+++ b/stories/login/pages/Terms.stories.tsx
@@ -67,9 +67,6 @@ export const LongMessage: Story = {
     render: () => (
         <KcPageStory
             kcContext={{
-                locale: {
-                    currentLanguageTag: "en"
-                },
                 "x-keycloakify": {
                     messages: {
                         termsText: `

--- a/stories/login/pages/Terms.stories.tsx
+++ b/stories/login/pages/Terms.stories.tsx
@@ -45,18 +45,6 @@ export const French: Story = {
         />
     )
 };
-export const WithErrorMessage: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                messagesPerField: {
-                    existsError: () => true,
-                    get: () => "An error occurred while processing your request."
-                }
-            }}
-        />
-    )
-};
 
 export const Spanish: Story = {
     render: () => (
@@ -68,6 +56,33 @@ export const Spanish: Story = {
                 "x-keycloakify": {
                     messages: {
                         termsText: "<p>Mis términos en <strong>Español</strong></p>"
+                    }
+                }
+            }}
+        />
+    )
+};
+
+export const LongMessage: Story = {
+    render: () => (
+        <KcPageStory
+            kcContext={{
+                locale: {
+                    currentLanguageTag: "en"
+                },
+                "x-keycloakify": {
+                    messages: {
+                        termsText: `
+                            <p>These are the terms and conditions. Please read them carefully.</p>
+                            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus lacinia odio vitae vestibulum vestibulum.</p>
+                            <p>Cras vehicula diam vel metus faucibus, at scelerisque lacus pretium. Donec ac consectetur justo. Morbi in sollicitudin nulla.</p>
+                            <p>Suspendisse potenti. Phasellus pharetra consequat ante, at dictum ligula volutpat a. Quisque ultricies velit nec nulla gravida accumsan.</p>
+                            <p>Curabitur tristique, magna id hendrerit tristique, enim nunc laoreet erat, non accumsan lacus arcu et nulla.</p>
+                            <p>Fusce feugiat nisi orci, in placerat dui luctus ut. Suspendisse in velit eu urna auctor consequat a euismod enim.</p>
+                            <p>Etiam et massa a sapien pharetra mollis. In lacinia quam id libero tincidunt, at egestas felis viverra.</p>
+                            <p>Nunc pulvinar imperdiet facilisis. Curabitur ultricies dictum lectus, nec consectetur metus fringilla id.</p>
+                            <p><strong>Please accept the terms to proceed.</strong></p>
+                        `
                     }
                 }
             }}


### PR DESCRIPTION
In addition to removing the error message on the terms and conditions page, I added a story for long terms and conditions. Since you brought this up, it reminded me that it was also a concern in my own personal project.

![image](https://github.com/user-attachments/assets/9d756200-6fb6-4d73-a967-1e882e90bb89)
