### PR TITLE
Draft: Use Story args instead of render()

### DIFF
--- a/stories/account/pages/Account.stories.tsx
+++ b/stories/account/pages/Account.stories.tsx
@@ -13,9 +13,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-    render: () => <KcPageStory />
-};
+export const Default: Story = {};
 
 /**
  * UsernameNotEditable:
@@ -24,32 +22,30 @@ export const Default: Story = {
  * - Key Aspect: Ensures that the `editUsernameAllowed` condition is respected and the username field is read-only.
  */
 export const UsernameNotEditable: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                account: {
-                    username: "john_doe",
-                    email: "john.doe@gmail.com",
-                    firstName: "John",
-                    lastName: "Doe"
-                },
-                realm: {
-                    registrationEmailAsUsername: false,
-                    editUsernameAllowed: false
-                },
-                referrer: {
-                    url: "/home"
-                },
-                url: {
-                    accountUrl: "/account"
-                },
-                messagesPerField: {
-                    printIfExists: () => ""
-                },
-                stateChecker: "state-checker"
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            account: {
+                username: "john_doe",
+                email: "john.doe@gmail.com",
+                firstName: "John",
+                lastName: "Doe"
+            },
+            realm: {
+                registrationEmailAsUsername: false,
+                editUsernameAllowed: false
+            },
+            referrer: {
+                url: "/home"
+            },
+            url: {
+                accountUrl: "/account"
+            },
+            messagesPerField: {
+                printIfExists: () => ""
+            },
+            stateChecker: "state-checker"
+        }
+    }
 };
 
 /**
@@ -59,32 +55,30 @@ export const UsernameNotEditable: Story = {
  * - Key Aspect: Ensures that error messages are properly displayed and the user can correct their inputs.
  */
 export const WithValidationErrors: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                account: {
-                    username: "john_doe",
-                    email: "",
-                    firstName: "",
-                    lastName: "Doe"
-                },
-                realm: {
-                    registrationEmailAsUsername: false,
-                    editUsernameAllowed: true
-                },
-                referrer: {
-                    url: "/home"
-                },
-                url: {
-                    accountUrl: "/account"
-                },
-                messagesPerField: {
-                    printIfExists: field => (field === "email" || field === "firstName" ? "has-error" : "")
-                },
-                stateChecker: "state-checker"
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            account: {
+                username: "john_doe",
+                email: "",
+                firstName: "",
+                lastName: "Doe"
+            },
+            realm: {
+                registrationEmailAsUsername: false,
+                editUsernameAllowed: true
+            },
+            referrer: {
+                url: "/home"
+            },
+            url: {
+                accountUrl: "/account"
+            },
+            messagesPerField: {
+                printIfExists: field => (field === "email" || field === "firstName" ? "has-error" : "")
+            },
+            stateChecker: "state-checker"
+        }
+    }
 };
 /**
  * EmailAsUsername:
@@ -93,28 +87,26 @@ export const WithValidationErrors: Story = {
  * - Key Aspect: Ensures the form functions correctly when `registrationEmailAsUsername` is enabled.
  */
 export const EmailAsUsername: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                account: {
-                    email: "john.doe@gmail.com",
-                    firstName: "John",
-                    lastName: "Doe"
-                },
-                realm: {
-                    registrationEmailAsUsername: true
-                },
-                referrer: {
-                    url: "/home"
-                },
-                url: {
-                    accountUrl: "/account"
-                },
-                messagesPerField: {
-                    printIfExists: () => ""
-                },
-                stateChecker: "state-checker"
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            account: {
+                email: "john.doe@gmail.com",
+                firstName: "John",
+                lastName: "Doe"
+            },
+            realm: {
+                registrationEmailAsUsername: true
+            },
+            referrer: {
+                url: "/home"
+            },
+            url: {
+                accountUrl: "/account"
+            },
+            messagesPerField: {
+                printIfExists: () => ""
+            },
+            stateChecker: "state-checker"
+        }
+    }
 };

--- a/stories/account/pages/Applications.stories.tsx
+++ b/stories/account/pages/Applications.stories.tsx
@@ -14,215 +14,203 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                pageId: "applications.ftl",
-                applications: {
-                    applications: [
-                        {
-                            realmRolesAvailable: [
-                                {
-                                    name: "realmRoleName1",
-                                    description: "realm role description 1"
-                                },
-                                {
-                                    name: "realmRoleName2",
-                                    description: "realm role description 2"
-                                }
-                            ],
-                            resourceRolesAvailable: {
-                                resource1: [
-                                    {
-                                        roleName: "Resource Role Name 1",
-                                        roleDescription: "Resource role 1 description",
-                                        clientName: "Client Name 1",
-                                        clientId: "client1"
-                                    }
-                                ],
-                                resource2: [
-                                    {
-                                        roleName: "Resource Role Name 2",
-                                        clientName: "Client Name 1",
-                                        clientId: "client1"
-                                    }
-                                ]
+    args: {
+        kcContext: {
+            pageId: "applications.ftl",
+            applications: {
+                applications: [
+                    {
+                        realmRolesAvailable: [
+                            {
+                                name: "realmRoleName1",
+                                description: "realm role description 1"
                             },
-                            additionalGrants: ["grant1", "grant2"],
-                            clientScopesGranted: ["scope1", "scope2"],
-                            effectiveUrl: "#",
-                            client: {
-                                clientId: "application1",
-                                name: "Application 1",
-                                consentRequired: true
+                            {
+                                name: "realmRoleName2",
+                                description: "realm role description 2"
                             }
-                        },
-                        {
-                            realmRolesAvailable: [
+                        ],
+                        resourceRolesAvailable: {
+                            resource1: [
                                 {
-                                    name: "Realm Role Name 1"
+                                    roleName: "Resource Role Name 1",
+                                    roleDescription: "Resource role 1 description",
+                                    clientName: "Client Name 1",
+                                    clientId: "client1"
                                 }
                             ],
-                            resourceRolesAvailable: {},
-                            additionalGrants: [],
-                            clientScopesGranted: [],
-                            effectiveUrl: "#",
-                            client: {
-                                clientId: "application2",
-                                name: "Application 2"
-                            }
+                            resource2: [
+                                {
+                                    roleName: "Resource Role Name 2",
+                                    clientName: "Client Name 1",
+                                    clientId: "client1"
+                                }
+                            ]
+                        },
+                        additionalGrants: ["grant1", "grant2"],
+                        clientScopesGranted: ["scope1", "scope2"],
+                        effectiveUrl: "#",
+                        client: {
+                            clientId: "application1",
+                            name: "Application 1",
+                            consentRequired: true
                         }
-                    ]
-                }
-            }}
-        />
-    )
+                    },
+                    {
+                        realmRolesAvailable: [
+                            {
+                                name: "Realm Role Name 1"
+                            }
+                        ],
+                        resourceRolesAvailable: {},
+                        additionalGrants: [],
+                        clientScopesGranted: [],
+                        effectiveUrl: "#",
+                        client: {
+                            clientId: "application2",
+                            name: "Application 2"
+                        }
+                    }
+                ]
+            }
+        }
+    }
 };
 
 // No Available Roles or Grants Scenario
 export const NoAvailableRolesOrGrants: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                pageId: "applications.ftl",
-                applications: {
-                    applications: [
-                        {
-                            realmRolesAvailable: [],
-                            resourceRolesAvailable: {},
-                            additionalGrants: [],
-                            clientScopesGranted: [],
-                            effectiveUrl: "#",
-                            client: {
-                                clientId: "application1",
-                                name: "Application 1",
-                                consentRequired: true
-                            }
+    args: {
+        kcContext: {
+            pageId: "applications.ftl",
+            applications: {
+                applications: [
+                    {
+                        realmRolesAvailable: [],
+                        resourceRolesAvailable: {},
+                        additionalGrants: [],
+                        clientScopesGranted: [],
+                        effectiveUrl: "#",
+                        client: {
+                            clientId: "application1",
+                            name: "Application 1",
+                            consentRequired: true
                         }
-                    ]
-                }
-            }}
-        />
-    )
+                    }
+                ]
+            }
+        }
+    }
 };
 
 // Consent Not Required Scenario
 export const ConsentNotRequired: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                pageId: "applications.ftl",
-                applications: {
-                    applications: [
-                        {
-                            realmRolesAvailable: [],
-                            resourceRolesAvailable: {},
-                            additionalGrants: [],
-                            clientScopesGranted: [],
-                            effectiveUrl: "#",
-                            client: {
-                                clientId: "application1",
-                                name: "Application 1",
-                                consentRequired: false // No consent required
-                            }
+    args: {
+        kcContext: {
+            pageId: "applications.ftl",
+            applications: {
+                applications: [
+                    {
+                        realmRolesAvailable: [],
+                        resourceRolesAvailable: {},
+                        additionalGrants: [],
+                        clientScopesGranted: [],
+                        effectiveUrl: "#",
+                        client: {
+                            clientId: "application1",
+                            name: "Application 1",
+                            consentRequired: false // No consent required
                         }
-                    ]
-                }
-            }}
-        />
-    )
+                    }
+                ]
+            }
+        }
+    }
 };
 
 // No Roles Available but Consent Required Scenario
 export const NoRolesButConsentRequired: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                pageId: "applications.ftl",
-                applications: {
-                    applications: [
-                        {
-                            realmRolesAvailable: [],
-                            resourceRolesAvailable: {},
-                            additionalGrants: [],
-                            clientScopesGranted: ["scope1", "scope2"], // Consent required but no roles
-                            effectiveUrl: "#",
-                            client: {
-                                clientId: "application1",
-                                name: "Application 1",
-                                consentRequired: true
-                            }
+    args: {
+        kcContext: {
+            pageId: "applications.ftl",
+            applications: {
+                applications: [
+                    {
+                        realmRolesAvailable: [],
+                        resourceRolesAvailable: {},
+                        additionalGrants: [],
+                        clientScopesGranted: ["scope1", "scope2"], // Consent required but no roles
+                        effectiveUrl: "#",
+                        client: {
+                            clientId: "application1",
+                            name: "Application 1",
+                            consentRequired: true
                         }
-                    ]
-                }
-            }}
-        />
-    )
+                    }
+                ]
+            }
+        }
+    }
 };
 
 // Only Resource Roles Available Scenario
 export const OnlyResourceRolesAvailable: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                pageId: "applications.ftl",
-                applications: {
-                    applications: [
-                        {
-                            realmRolesAvailable: [], // No realm roles
-                            resourceRolesAvailable: {
-                                resource1: [
-                                    {
-                                        roleName: "Resource Role Name 1",
-                                        roleDescription: "Resource role 1 description",
-                                        clientName: "Client Name 1",
-                                        clientId: "client1"
-                                    }
-                                ]
-                            },
-                            additionalGrants: [],
-                            clientScopesGranted: [],
-                            effectiveUrl: "#",
-                            client: {
-                                clientId: "application1",
-                                name: "Application 1",
-                                consentRequired: true
-                            }
+    args: {
+        kcContext: {
+            pageId: "applications.ftl",
+            applications: {
+                applications: [
+                    {
+                        realmRolesAvailable: [], // No realm roles
+                        resourceRolesAvailable: {
+                            resource1: [
+                                {
+                                    roleName: "Resource Role Name 1",
+                                    roleDescription: "Resource role 1 description",
+                                    clientName: "Client Name 1",
+                                    clientId: "client1"
+                                }
+                            ]
+                        },
+                        additionalGrants: [],
+                        clientScopesGranted: [],
+                        effectiveUrl: "#",
+                        client: {
+                            clientId: "application1",
+                            name: "Application 1",
+                            consentRequired: true
                         }
-                    ]
-                }
-            }}
-        />
-    )
+                    }
+                ]
+            }
+        }
+    }
 };
 
 // No Additional Grants Scenario
 export const NoAdditionalGrants: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                pageId: "applications.ftl",
-                applications: {
-                    applications: [
-                        {
-                            realmRolesAvailable: [
-                                {
-                                    name: "Realm Role Name 1"
-                                }
-                            ],
-                            resourceRolesAvailable: {},
-                            additionalGrants: [], // No additional grants
-                            clientScopesGranted: [],
-                            effectiveUrl: "#",
-                            client: {
-                                clientId: "application1",
-                                name: "Application 1",
-                                consentRequired: true
+    args: {
+        kcContext: {
+            pageId: "applications.ftl",
+            applications: {
+                applications: [
+                    {
+                        realmRolesAvailable: [
+                            {
+                                name: "Realm Role Name 1"
                             }
+                        ],
+                        resourceRolesAvailable: {},
+                        additionalGrants: [], // No additional grants
+                        clientScopesGranted: [],
+                        effectiveUrl: "#",
+                        client: {
+                            clientId: "application1",
+                            name: "Application 1",
+                            consentRequired: true
                         }
-                    ]
-                }
-            }}
-        />
-    )
+                    }
+                ]
+            }
+        }
+    }
 };

--- a/stories/account/pages/FederatedIdentity.stories.tsx
+++ b/stories/account/pages/FederatedIdentity.stories.tsx
@@ -13,28 +13,24 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-    render: () => <KcPageStory />
-};
+export const Default: Story = {};
 
 export const NotConnected: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                pageId: "federatedIdentity.ftl",
-                federatedIdentity: {
-                    identities: [
-                        {
-                            providerId: "google",
-                            displayName: "keycloak-oidc",
-                            connected: false
-                        }
-                    ],
-                    removeLinkPossible: true
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            pageId: "federatedIdentity.ftl",
+            federatedIdentity: {
+                identities: [
+                    {
+                        providerId: "google",
+                        displayName: "keycloak-oidc",
+                        connected: false
+                    }
+                ],
+                removeLinkPossible: true
+            }
+        }
+    }
 };
 
 /**
@@ -42,28 +38,26 @@ export const NotConnected: Story = {
  * - Federated identities are connected, but the user cannot remove them due to restrictions.
  */
 export const RemoveLinkNotPossible: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                pageId: "federatedIdentity.ftl",
-                federatedIdentity: {
-                    identities: [
-                        {
-                            providerId: "google",
-                            displayName: "Google",
-                            userName: "john.doe@gmail.com",
-                            connected: true
-                        }
-                    ],
-                    removeLinkPossible: false
-                },
-                stateChecker: "1234",
-                url: {
-                    socialUrl: "/social"
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            pageId: "federatedIdentity.ftl",
+            federatedIdentity: {
+                identities: [
+                    {
+                        providerId: "google",
+                        displayName: "Google",
+                        userName: "john.doe@gmail.com",
+                        connected: true
+                    }
+                ],
+                removeLinkPossible: false
+            },
+            stateChecker: "1234",
+            url: {
+                socialUrl: "/social"
+            }
+        }
+    }
 };
 
 /**
@@ -71,26 +65,24 @@ export const RemoveLinkNotPossible: Story = {
  * - The user has an identity that is not connected and can add it.
  */
 export const AddLinkForUnconnectedIdentity: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                pageId: "federatedIdentity.ftl",
-                federatedIdentity: {
-                    identities: [
-                        {
-                            providerId: "github",
-                            displayName: "GitHub",
-                            userName: "",
-                            connected: false
-                        }
-                    ],
-                    removeLinkPossible: true
-                },
-                stateChecker: "1234",
-                url: {
-                    socialUrl: "/social"
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            pageId: "federatedIdentity.ftl",
+            federatedIdentity: {
+                identities: [
+                    {
+                        providerId: "github",
+                        displayName: "GitHub",
+                        userName: "",
+                        connected: false
+                    }
+                ],
+                removeLinkPossible: true
+            },
+            stateChecker: "1234",
+            url: {
+                socialUrl: "/social"
+            }
+        }
+    }
 };

--- a/stories/account/pages/Log.stories.tsx
+++ b/stories/account/pages/Log.stories.tsx
@@ -17,445 +17,433 @@ type Story = StoryObj<typeof meta>;
 
 // NOTE: Enable in your Keycloak realm with: https://github.com/user-attachments/assets/5fc5e49e-a172-4cb0-897a-49baac284b47
 export const Default: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                log: {
-                    events: [
-                        {
-                            date: "2024-04-26T12:29:08Z",
-                            ipAddress: "127.0.0.1",
-                            client: "keycloakify-frontend",
-                            details: [
-                                {
-                                    value: "openid-connect",
-                                    key: "auth_method"
-                                },
-                                {
-                                    value: "john.doe",
-                                    key: "username"
-                                }
-                            ],
-                            event: "login"
-                        },
-                        {
-                            date: "2024-04-26T12:10:56Z",
-                            ipAddress: "127.0.0.1",
-                            client: "keycloakify-frontend",
-                            details: [
-                                {
-                                    value: "openid-connect",
-                                    key: "auth_method"
-                                },
-                                {
-                                    value: "john.doe",
-                                    key: "username"
-                                }
-                            ],
-                            event: "login"
-                        },
-                        {
-                            date: "2024-04-26T11:57:34Z",
-                            ipAddress: "127.0.0.1",
-                            client: "account",
-                            details: [],
-                            event: "update totp"
-                        },
-                        {
-                            date: "2024-04-26T11:57:21Z",
-                            ipAddress: "127.0.0.1",
-                            client: "account",
-                            details: [],
-                            event: "update totp"
-                        },
-                        {
-                            date: "2024-04-26T11:56:56Z",
-                            ipAddress: "127.0.0.1",
-                            client: "account",
-                            details: [],
-                            event: "remove totp"
-                        },
-                        {
-                            date: "2024-04-26T11:56:55Z",
-                            ipAddress: "127.0.0.1",
-                            client: "account",
-                            details: [],
-                            event: "remove totp"
-                        },
-                        {
-                            date: "2024-04-26T11:56:41Z",
-                            ipAddress: "127.0.0.1",
-                            client: "account",
-                            details: [],
-                            event: "update totp"
-                        },
-                        {
-                            date: "2024-04-26T11:56:36Z",
-                            ipAddress: "127.0.0.1",
-                            client: "account",
-                            details: [],
-                            event: "update totp"
-                        },
-                        {
-                            date: "2024-04-26T11:32:54Z",
-                            ipAddress: "127.0.0.1",
-                            client: "keycloakify-frontend",
-                            details: [
-                                {
-                                    value: "openid-connect",
-                                    key: "auth_method"
-                                },
-                                {
-                                    value: "john.doe",
-                                    key: "username"
-                                }
-                            ],
-                            event: "login"
-                        },
-                        {
-                            date: "2024-04-26T09:42:54Z",
-                            ipAddress: "127.0.0.1",
-                            client: "keycloakify-frontend",
-                            details: [
-                                {
-                                    value: "openid-connect",
-                                    key: "auth_method"
-                                },
-                                {
-                                    value: "john.doe",
-                                    key: "username"
-                                }
-                            ],
-                            event: "login"
-                        },
-                        {
-                            date: "2024-04-26T09:42:52Z",
-                            ipAddress: "127.0.0.1",
-                            client: "keycloakify-frontend",
-                            details: [
-                                {
-                                    value: "openid-connect",
-                                    key: "auth_method"
-                                },
-                                {
-                                    value: "john.doe",
-                                    key: "username"
-                                }
-                            ],
-                            event: "login"
-                        },
-                        {
-                            date: "2024-04-26T09:42:40Z",
-                            ipAddress: "127.0.0.1",
-                            client: "keycloakify-frontend",
-                            details: [
-                                {
-                                    value: "openid-connect",
-                                    key: "auth_method"
-                                },
-                                {
-                                    value: "john.doe",
-                                    key: "username"
-                                }
-                            ],
-                            event: "login"
-                        },
-                        {
-                            date: "2024-04-26T09:42:09Z",
-                            ipAddress: "127.0.0.1",
-                            client: "keycloakify-frontend",
-                            details: [
-                                {
-                                    value: "openid-connect",
-                                    key: "auth_method"
-                                },
-                                {
-                                    value: "false",
-                                    key: "remember_me"
-                                },
-                                {
-                                    value: "john.doe",
-                                    key: "username"
-                                }
-                            ],
-                            event: "login"
-                        },
-                        {
-                            date: "2024-04-26T09:24:17Z",
-                            ipAddress: "127.0.0.1",
-                            client: "keycloakify-frontend",
-                            details: [],
-                            event: "logout"
-                        },
-                        {
-                            date: "2024-04-26T09:23:54Z",
-                            ipAddress: "127.0.0.1",
-                            client: "keycloakify-frontend",
-                            details: [
-                                {
-                                    value: "openid-connect",
-                                    key: "auth_method"
-                                },
-                                {
-                                    value: "john.doe",
-                                    key: "username"
-                                }
-                            ],
-                            event: "login"
-                        },
-                        {
-                            date: "2024-04-26T09:23:50Z",
-                            ipAddress: "127.0.0.1",
-                            client: "keycloakify-frontend",
-                            details: [
-                                {
-                                    value: "openid-connect",
-                                    key: "auth_method"
-                                },
-                                {
-                                    value: "john.doe",
-                                    key: "username"
-                                }
-                            ],
-                            event: "login"
-                        },
-                        {
-                            date: "2024-04-26T09:23:47Z",
-                            ipAddress: "127.0.0.1",
-                            client: "account",
-                            details: [
-                                {
-                                    value: "openid-connect",
-                                    key: "auth_method"
-                                },
-                                {
-                                    value: "john.doe",
-                                    key: "username"
-                                }
-                            ],
-                            event: "login"
-                        },
-                        {
-                            date: "2024-04-26T09:23:15Z",
-                            ipAddress: "127.0.0.1",
-                            client: "keycloakify-frontend",
-                            details: [],
-                            event: "logout"
-                        },
-                        {
-                            date: "2024-04-26T09:23:06Z",
-                            ipAddress: "127.0.0.1",
-                            client: "keycloakify-frontend",
-                            details: [
-                                {
-                                    value: "openid-connect",
-                                    key: "auth_method"
-                                },
-                                {
-                                    value: "john.doe",
-                                    key: "username"
-                                }
-                            ],
-                            event: "login"
-                        },
-                        {
-                            date: "2024-04-26T09:22:53Z",
-                            ipAddress: "127.0.0.1",
-                            client: "keycloakify-frontend",
-                            details: [],
-                            event: "logout"
-                        },
-                        {
-                            date: "2024-04-26T09:21:29Z",
-                            ipAddress: "127.0.0.1",
-                            client: "keycloakify-frontend",
-                            details: [
-                                {
-                                    value: "openid-connect",
-                                    key: "auth_method"
-                                },
-                                {
-                                    value: "false",
-                                    key: "remember_me"
-                                },
-                                {
-                                    value: "john.doe",
-                                    key: "username"
-                                }
-                            ],
-                            event: "login"
-                        },
-                        {
-                            date: "2024-04-26T09:17:32Z",
-                            ipAddress: "127.0.0.1",
-                            client: "keycloakify-frontend",
-                            details: [
-                                {
-                                    value: "openid-connect",
-                                    key: "auth_method"
-                                },
-                                {
-                                    value: "john.doe",
-                                    key: "username"
-                                }
-                            ],
-                            event: "login"
-                        },
-                        {
-                            date: "2024-04-18T11:19:09Z",
-                            ipAddress: "127.0.0.1",
-                            client: "keycloakify-frontend",
-                            details: [
-                                {
-                                    value: "openid-connect",
-                                    key: "auth_method"
-                                },
-                                {
-                                    value: "john.doe",
-                                    key: "username"
-                                }
-                            ],
-                            event: "login"
-                        },
-                        {
-                            date: "2024-04-18T11:18:50Z",
-                            ipAddress: "127.0.0.1",
-                            client: "keycloakify-frontend",
-                            details: [
-                                {
-                                    value: "openid-connect",
-                                    key: "auth_method"
-                                },
-                                {
-                                    value: "john.doe",
-                                    key: "username"
-                                }
-                            ],
-                            event: "login"
-                        },
-                        {
-                            date: "2024-04-18T11:18:24Z",
-                            ipAddress: "127.0.0.1",
-                            client: "account",
-                            details: [
-                                {
-                                    value: "openid-connect",
-                                    key: "auth_method"
-                                },
-                                {
-                                    value: "john.doe",
-                                    key: "username"
-                                }
-                            ],
-                            event: "login"
-                        }
-                    ]
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            log: {
+                events: [
+                    {
+                        date: "2024-04-26T12:29:08Z",
+                        ipAddress: "127.0.0.1",
+                        client: "keycloakify-frontend",
+                        details: [
+                            {
+                                value: "openid-connect",
+                                key: "auth_method"
+                            },
+                            {
+                                value: "john.doe",
+                                key: "username"
+                            }
+                        ],
+                        event: "login"
+                    },
+                    {
+                        date: "2024-04-26T12:10:56Z",
+                        ipAddress: "127.0.0.1",
+                        client: "keycloakify-frontend",
+                        details: [
+                            {
+                                value: "openid-connect",
+                                key: "auth_method"
+                            },
+                            {
+                                value: "john.doe",
+                                key: "username"
+                            }
+                        ],
+                        event: "login"
+                    },
+                    {
+                        date: "2024-04-26T11:57:34Z",
+                        ipAddress: "127.0.0.1",
+                        client: "account",
+                        details: [],
+                        event: "update totp"
+                    },
+                    {
+                        date: "2024-04-26T11:57:21Z",
+                        ipAddress: "127.0.0.1",
+                        client: "account",
+                        details: [],
+                        event: "update totp"
+                    },
+                    {
+                        date: "2024-04-26T11:56:56Z",
+                        ipAddress: "127.0.0.1",
+                        client: "account",
+                        details: [],
+                        event: "remove totp"
+                    },
+                    {
+                        date: "2024-04-26T11:56:55Z",
+                        ipAddress: "127.0.0.1",
+                        client: "account",
+                        details: [],
+                        event: "remove totp"
+                    },
+                    {
+                        date: "2024-04-26T11:56:41Z",
+                        ipAddress: "127.0.0.1",
+                        client: "account",
+                        details: [],
+                        event: "update totp"
+                    },
+                    {
+                        date: "2024-04-26T11:56:36Z",
+                        ipAddress: "127.0.0.1",
+                        client: "account",
+                        details: [],
+                        event: "update totp"
+                    },
+                    {
+                        date: "2024-04-26T11:32:54Z",
+                        ipAddress: "127.0.0.1",
+                        client: "keycloakify-frontend",
+                        details: [
+                            {
+                                value: "openid-connect",
+                                key: "auth_method"
+                            },
+                            {
+                                value: "john.doe",
+                                key: "username"
+                            }
+                        ],
+                        event: "login"
+                    },
+                    {
+                        date: "2024-04-26T09:42:54Z",
+                        ipAddress: "127.0.0.1",
+                        client: "keycloakify-frontend",
+                        details: [
+                            {
+                                value: "openid-connect",
+                                key: "auth_method"
+                            },
+                            {
+                                value: "john.doe",
+                                key: "username"
+                            }
+                        ],
+                        event: "login"
+                    },
+                    {
+                        date: "2024-04-26T09:42:52Z",
+                        ipAddress: "127.0.0.1",
+                        client: "keycloakify-frontend",
+                        details: [
+                            {
+                                value: "openid-connect",
+                                key: "auth_method"
+                            },
+                            {
+                                value: "john.doe",
+                                key: "username"
+                            }
+                        ],
+                        event: "login"
+                    },
+                    {
+                        date: "2024-04-26T09:42:40Z",
+                        ipAddress: "127.0.0.1",
+                        client: "keycloakify-frontend",
+                        details: [
+                            {
+                                value: "openid-connect",
+                                key: "auth_method"
+                            },
+                            {
+                                value: "john.doe",
+                                key: "username"
+                            }
+                        ],
+                        event: "login"
+                    },
+                    {
+                        date: "2024-04-26T09:42:09Z",
+                        ipAddress: "127.0.0.1",
+                        client: "keycloakify-frontend",
+                        details: [
+                            {
+                                value: "openid-connect",
+                                key: "auth_method"
+                            },
+                            {
+                                value: "false",
+                                key: "remember_me"
+                            },
+                            {
+                                value: "john.doe",
+                                key: "username"
+                            }
+                        ],
+                        event: "login"
+                    },
+                    {
+                        date: "2024-04-26T09:24:17Z",
+                        ipAddress: "127.0.0.1",
+                        client: "keycloakify-frontend",
+                        details: [],
+                        event: "logout"
+                    },
+                    {
+                        date: "2024-04-26T09:23:54Z",
+                        ipAddress: "127.0.0.1",
+                        client: "keycloakify-frontend",
+                        details: [
+                            {
+                                value: "openid-connect",
+                                key: "auth_method"
+                            },
+                            {
+                                value: "john.doe",
+                                key: "username"
+                            }
+                        ],
+                        event: "login"
+                    },
+                    {
+                        date: "2024-04-26T09:23:50Z",
+                        ipAddress: "127.0.0.1",
+                        client: "keycloakify-frontend",
+                        details: [
+                            {
+                                value: "openid-connect",
+                                key: "auth_method"
+                            },
+                            {
+                                value: "john.doe",
+                                key: "username"
+                            }
+                        ],
+                        event: "login"
+                    },
+                    {
+                        date: "2024-04-26T09:23:47Z",
+                        ipAddress: "127.0.0.1",
+                        client: "account",
+                        details: [
+                            {
+                                value: "openid-connect",
+                                key: "auth_method"
+                            },
+                            {
+                                value: "john.doe",
+                                key: "username"
+                            }
+                        ],
+                        event: "login"
+                    },
+                    {
+                        date: "2024-04-26T09:23:15Z",
+                        ipAddress: "127.0.0.1",
+                        client: "keycloakify-frontend",
+                        details: [],
+                        event: "logout"
+                    },
+                    {
+                        date: "2024-04-26T09:23:06Z",
+                        ipAddress: "127.0.0.1",
+                        client: "keycloakify-frontend",
+                        details: [
+                            {
+                                value: "openid-connect",
+                                key: "auth_method"
+                            },
+                            {
+                                value: "john.doe",
+                                key: "username"
+                            }
+                        ],
+                        event: "login"
+                    },
+                    {
+                        date: "2024-04-26T09:22:53Z",
+                        ipAddress: "127.0.0.1",
+                        client: "keycloakify-frontend",
+                        details: [],
+                        event: "logout"
+                    },
+                    {
+                        date: "2024-04-26T09:21:29Z",
+                        ipAddress: "127.0.0.1",
+                        client: "keycloakify-frontend",
+                        details: [
+                            {
+                                value: "openid-connect",
+                                key: "auth_method"
+                            },
+                            {
+                                value: "false",
+                                key: "remember_me"
+                            },
+                            {
+                                value: "john.doe",
+                                key: "username"
+                            }
+                        ],
+                        event: "login"
+                    },
+                    {
+                        date: "2024-04-26T09:17:32Z",
+                        ipAddress: "127.0.0.1",
+                        client: "keycloakify-frontend",
+                        details: [
+                            {
+                                value: "openid-connect",
+                                key: "auth_method"
+                            },
+                            {
+                                value: "john.doe",
+                                key: "username"
+                            }
+                        ],
+                        event: "login"
+                    },
+                    {
+                        date: "2024-04-18T11:19:09Z",
+                        ipAddress: "127.0.0.1",
+                        client: "keycloakify-frontend",
+                        details: [
+                            {
+                                value: "openid-connect",
+                                key: "auth_method"
+                            },
+                            {
+                                value: "john.doe",
+                                key: "username"
+                            }
+                        ],
+                        event: "login"
+                    },
+                    {
+                        date: "2024-04-18T11:18:50Z",
+                        ipAddress: "127.0.0.1",
+                        client: "keycloakify-frontend",
+                        details: [
+                            {
+                                value: "openid-connect",
+                                key: "auth_method"
+                            },
+                            {
+                                value: "john.doe",
+                                key: "username"
+                            }
+                        ],
+                        event: "login"
+                    },
+                    {
+                        date: "2024-04-18T11:18:24Z",
+                        ipAddress: "127.0.0.1",
+                        client: "account",
+                        details: [
+                            {
+                                value: "openid-connect",
+                                key: "auth_method"
+                            },
+                            {
+                                value: "john.doe",
+                                key: "username"
+                            }
+                        ],
+                        event: "login"
+                    }
+                ]
+            }
+        }
+    }
 };
 export const LogsMissingDetails: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                pageId: "log.ftl",
-                log: {
-                    events: [
-                        {
-                            date: "2024-04-26T12:29:08Z",
-                            ipAddress: "127.0.0.1",
-                            client: "",
-                            details: [],
-                            event: "login"
-                        }
-                    ]
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            pageId: "log.ftl",
+            log: {
+                events: [
+                    {
+                        date: "2024-04-26T12:29:08Z",
+                        ipAddress: "127.0.0.1",
+                        client: "",
+                        details: [],
+                        event: "login"
+                    }
+                ]
+            }
+        }
+    }
 };
 export const SingleLogEntry: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                pageId: "log.ftl",
-                log: {
-                    events: [
-                        {
-                            date: "2024-04-26T12:29:08Z",
-                            ipAddress: "127.0.0.1",
-                            client: "keycloakify-frontend",
-                            details: [
-                                { key: "auth_method", value: "openid-connect" },
-                                { key: "username", value: "john.doe" }
-                            ],
-                            event: "login"
-                        }
-                    ]
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            pageId: "log.ftl",
+            log: {
+                events: [
+                    {
+                        date: "2024-04-26T12:29:08Z",
+                        ipAddress: "127.0.0.1",
+                        client: "keycloakify-frontend",
+                        details: [
+                            { key: "auth_method", value: "openid-connect" },
+                            { key: "username", value: "john.doe" }
+                        ],
+                        event: "login"
+                    }
+                ]
+            }
+        }
+    }
 };
 export const LogsWithLongDetails: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                pageId: "log.ftl",
-                log: {
-                    events: [
-                        {
-                            date: "2024-04-26T12:29:08Z",
-                            ipAddress: "127.0.0.1",
-                            client: "keycloakify-frontend",
-                            details: [
-                                { key: "auth_method", value: "openid-connect" },
-                                { key: "username", value: "john.doe" },
-                                { key: "session_duration", value: "2 hours 30 minutes 45 seconds" },
-                                { key: "location", value: "Windsor, Ontario, Canada" },
-                                { key: "user_agent", value: "Mozilla/5.0 (Windows NT 10.0; Win64; x64)" }
-                            ],
-                            event: "login"
-                        }
-                    ]
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            pageId: "log.ftl",
+            log: {
+                events: [
+                    {
+                        date: "2024-04-26T12:29:08Z",
+                        ipAddress: "127.0.0.1",
+                        client: "keycloakify-frontend",
+                        details: [
+                            { key: "auth_method", value: "openid-connect" },
+                            { key: "username", value: "john.doe" },
+                            { key: "session_duration", value: "2 hours 30 minutes 45 seconds" },
+                            { key: "location", value: "Windsor, Ontario, Canada" },
+                            { key: "user_agent", value: "Mozilla/5.0 (Windows NT 10.0; Win64; x64)" }
+                        ],
+                        event: "login"
+                    }
+                ]
+            }
+        }
+    }
 };
 export const EmptyClientField: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                pageId: "log.ftl",
-                log: {
-                    events: [
-                        {
-                            date: "2024-04-26T12:29:08Z",
-                            ipAddress: "127.0.0.1",
-                            client: "", // Empty client field
-                            details: [
-                                { key: "auth_method", value: "openid-connect" },
-                                { key: "username", value: "john.doe" }
-                            ],
-                            event: "login"
-                        }
-                    ]
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            pageId: "log.ftl",
+            log: {
+                events: [
+                    {
+                        date: "2024-04-26T12:29:08Z",
+                        ipAddress: "127.0.0.1",
+                        client: "", // Empty client field
+                        details: [
+                            { key: "auth_method", value: "openid-connect" },
+                            { key: "username", value: "john.doe" }
+                        ],
+                        event: "login"
+                    }
+                ]
+            }
+        }
+    }
 };
 export const NoLogsAvailable: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                pageId: "log.ftl",
-                log: {
-                    events: [] // No log events
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            pageId: "log.ftl",
+            log: {
+                events: [] // No log events
+            }
+        }
+    }
 };

--- a/stories/account/pages/Password.stories.tsx
+++ b/stories/account/pages/Password.stories.tsx
@@ -13,18 +13,14 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-    render: () => <KcPageStory />
-};
+export const Default: Story = {};
 
 export const WithMessage: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                message: { type: "success", summary: "This is a test message" }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            message: { type: "success", summary: "This is a test message" }
+        }
+    }
 };
 /**
  * FirstTimePasswordSetup:
@@ -33,22 +29,20 @@ export const WithMessage: Story = {
  * - Key Aspect: Ensures the page only displays fields for setting a new password.
  */
 export const FirstTimePasswordSetup: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                account: {
-                    username: "john_doe"
-                },
-                password: {
-                    passwordSet: false
-                },
-                url: {
-                    passwordUrl: "/password"
-                },
-                stateChecker: "state-checker"
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            account: {
+                username: "john_doe"
+            },
+            password: {
+                passwordSet: false
+            },
+            url: {
+                passwordUrl: "/password"
+            },
+            stateChecker: "state-checker"
+        }
+    }
 };
 
 /**
@@ -58,23 +52,21 @@ export const FirstTimePasswordSetup: Story = {
  * - Key Aspect: Validates that an error message is correctly displayed for the current password input.
  */
 export const IncorrectCurrentPassword: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                message: { type: "error", summary: "Incorrect current password." },
-                account: {
-                    username: "john_doe"
-                },
-                password: {
-                    passwordSet: true
-                },
-                url: {
-                    passwordUrl: "/password"
-                },
-                stateChecker: "state-checker"
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            message: { type: "error", summary: "Incorrect current password." },
+            account: {
+                username: "john_doe"
+            },
+            password: {
+                passwordSet: true
+            },
+            url: {
+                passwordUrl: "/password"
+            },
+            stateChecker: "state-checker"
+        }
+    }
 };
 
 /**
@@ -84,21 +76,19 @@ export const IncorrectCurrentPassword: Story = {
  * - Key Aspect: Verifies the handling of successful submissions.
  */
 export const SubmissionSuccessWithRedirect: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                message: { type: "success", summary: "Password successfully changed." },
-                account: {
-                    username: "john_doe"
-                },
-                password: {
-                    passwordSet: true
-                },
-                url: {
-                    passwordUrl: "/password"
-                },
-                stateChecker: "state-checker"
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            message: { type: "success", summary: "Password successfully changed." },
+            account: {
+                username: "john_doe"
+            },
+            password: {
+                passwordSet: true
+            },
+            url: {
+                passwordUrl: "/password"
+            },
+            stateChecker: "state-checker"
+        }
+    }
 };

--- a/stories/account/pages/Sessions.stories.tsx
+++ b/stories/account/pages/Sessions.stories.tsx
@@ -14,64 +14,58 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                sessions: {
-                    sessions: [
-                        {
-                            expires: "2024-04-26T18:14:19Z",
-                            clients: ["account"],
-                            ipAddress: "172.20.0.1",
-                            started: "2024-04-26T08:14:19Z",
-                            lastAccess: "2024-04-26T08:30:54Z",
-                            id: "af835e30-4821-43b1-b4f7-e732d3cc15d2"
-                        },
-                        {
-                            expires: "2024-04-26T18:14:09Z",
-                            clients: ["security-admin-console", "account"],
-                            ipAddress: "172.20.0.1",
-                            started: "2024-04-26T08:14:09Z",
-                            lastAccess: "2024-04-26T08:15:14Z",
-                            id: "60a9d8b8-617d-441e-8643-08c3fe30e231"
-                        }
-                    ]
-                },
-                stateChecker: "xQ7EOgFrLi4EvnJ8dbXKhwFGWk_bkOp0X89mhilt1os"
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            sessions: {
+                sessions: [
+                    {
+                        expires: "2024-04-26T18:14:19Z",
+                        clients: ["account"],
+                        ipAddress: "172.20.0.1",
+                        started: "2024-04-26T08:14:19Z",
+                        lastAccess: "2024-04-26T08:30:54Z",
+                        id: "af835e30-4821-43b1-b4f7-e732d3cc15d2"
+                    },
+                    {
+                        expires: "2024-04-26T18:14:09Z",
+                        clients: ["security-admin-console", "account"],
+                        ipAddress: "172.20.0.1",
+                        started: "2024-04-26T08:14:09Z",
+                        lastAccess: "2024-04-26T08:15:14Z",
+                        id: "60a9d8b8-617d-441e-8643-08c3fe30e231"
+                    }
+                ]
+            },
+            stateChecker: "xQ7EOgFrLi4EvnJ8dbXKhwFGWk_bkOp0X89mhilt1os"
+        }
+    }
 };
 
 export const WithError: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                url: { passwordUrl: "/auth/realms/keycloakify/account/password" },
-                stateChecker: "xQ7EOgFrLi4EvnJ8dbXKhwFGWk_bkOp0X89mhilt1os",
-                message: {
-                    summary: "Invalid existing password.",
-                    type: "error"
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            url: { passwordUrl: "/auth/realms/keycloakify/account/password" },
+            stateChecker: "xQ7EOgFrLi4EvnJ8dbXKhwFGWk_bkOp0X89mhilt1os",
+            message: {
+                summary: "Invalid existing password.",
+                type: "error"
+            }
+        }
+    }
 };
 /**
  * No active sessions scenario:
  * - Simulates the scenario where no sessions are active for the user.
  */
 export const NoActiveSessions: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                sessions: {
-                    sessions: []
-                },
-                stateChecker: "randomStateCheckerValue"
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            sessions: {
+                sessions: []
+            },
+            stateChecker: "randomStateCheckerValue"
+        }
+    }
 };
 
 /**
@@ -79,25 +73,23 @@ export const NoActiveSessions: Story = {
  * - Displays only one active session with session details.
  */
 export const SingleSession: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                sessions: {
-                    sessions: [
-                        {
-                            expires: "2024-04-26T18:14:19Z",
-                            clients: ["account"],
-                            ipAddress: "172.20.0.1",
-                            started: "2024-04-26T08:14:19Z",
-                            lastAccess: "2024-04-26T08:30:54Z",
-                            id: "single-session-id"
-                        }
-                    ]
-                },
-                stateChecker: "anotherStateChecker"
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            sessions: {
+                sessions: [
+                    {
+                        expires: "2024-04-26T18:14:19Z",
+                        clients: ["account"],
+                        ipAddress: "172.20.0.1",
+                        started: "2024-04-26T08:14:19Z",
+                        lastAccess: "2024-04-26T08:30:54Z",
+                        id: "single-session-id"
+                    }
+                ]
+            },
+            stateChecker: "anotherStateChecker"
+        }
+    }
 };
 
 /**
@@ -105,25 +97,23 @@ export const SingleSession: Story = {
  * - Displays sessions where each session has multiple associated clients.
  */
 export const MultipleClientsSession: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                sessions: {
-                    sessions: [
-                        {
-                            expires: "2024-04-26T18:14:19Z",
-                            clients: ["account", "admin-console", "another-client"],
-                            ipAddress: "172.20.0.1",
-                            started: "2024-04-26T08:14:19Z",
-                            lastAccess: "2024-04-26T08:30:54Z",
-                            id: "multiple-clients-session"
-                        }
-                    ]
-                },
-                stateChecker: "multiClientsStateChecker"
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            sessions: {
+                sessions: [
+                    {
+                        expires: "2024-04-26T18:14:19Z",
+                        clients: ["account", "admin-console", "another-client"],
+                        ipAddress: "172.20.0.1",
+                        started: "2024-04-26T08:14:19Z",
+                        lastAccess: "2024-04-26T08:30:54Z",
+                        id: "multiple-clients-session"
+                    }
+                ]
+            },
+            stateChecker: "multiClientsStateChecker"
+        }
+    }
 };
 
 /**
@@ -131,23 +121,21 @@ export const MultipleClientsSession: Story = {
  * - Simulates a session where no client information is provided.
  */
 export const SessionWithoutClients: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                sessions: {
-                    sessions: [
-                        {
-                            expires: "2024-04-26T18:14:19Z",
-                            clients: [], // No clients information
-                            ipAddress: "172.20.0.1",
-                            started: "2024-04-26T08:14:19Z",
-                            lastAccess: "2024-04-26T08:30:54Z",
-                            id: "no-clients-session"
-                        }
-                    ]
-                },
-                stateChecker: "noClientsStateChecker"
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            sessions: {
+                sessions: [
+                    {
+                        expires: "2024-04-26T18:14:19Z",
+                        clients: [], // No clients information
+                        ipAddress: "172.20.0.1",
+                        started: "2024-04-26T08:14:19Z",
+                        lastAccess: "2024-04-26T08:30:54Z",
+                        id: "no-clients-session"
+                    }
+                ]
+            },
+            stateChecker: "noClientsStateChecker"
+        }
+    }
 };

--- a/stories/account/pages/Totp.stories.tsx
+++ b/stories/account/pages/Totp.stories.tsx
@@ -14,230 +14,216 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                totp: {
-                    enabled: false,
-                    totpSecretEncoded: "HE4W MSTC OBKU CY2M ONXF OV3Q NYYU I3SH",
-                    totpSecret: "99fJbpUAcLsnWWpn1DnG",
-                    manualUrl: "http://localhost:8080/realms/myrealm/account/totp?mode=manual",
-                    totpSecretQrCode:
-                        "iVBORw0KGgoAAAANSUhEUgAAAPYAAAD2AQAAAADNaUdlAAACk0lEQVR4Xu2YQY6DMAxFjViw5AjcBC6GBBIXozfJEbpkger53wEKqOpmFvaikQYNeVRyHPvbiejXscp95jp+/D5zHT9+n7kO8qeIFDqKzjJo9dC1wUSPP7yG4IPq41lq9ZK+keLZSwXDGwMhOCZgdX4sBVD1qld+GYg/h6ScreBuIDo5FKfVM7Z8aWs9PB2E2/73DdOlwUrK9Ck+HDnzB7ziR8fjlD/OPI8pVQwCi899TkNw2M+tp9XSLFKPIq2UySIhBB906fCQTicFwiv1EUG6+d+bl4zPIYnUk5oIcS69/evPYStUp6P0dJhD/mhauijcth76mOsfw+GFrbfXKJx7LW2N15kijuWIMCYicLQOCEimDp1c0L8PzCLTs3/d+ZQLyl6VqeSIT9nz25szf2ZybHgC31yrXEQIbqaPjX0k9GqWy0N/nLkagsHWNXR0LZwsR357c0pjC6fm+meu5f6f6oszz/qj7GpYCdHf0LVH/gTgtJ/5bVavPJ9svwnBS9qaqwoHOh3G7Ln++HIIDgpKYpFW00dlkX7ruz836THBWQpzd23/xeDsFVroz15fRjsfMyaC8JX2Y8PZf+VIoKff+uTO6WSIUIfSkrl9/rbfnbPr30R8hnMtXA/98ea5lx4ZlSMgQlMsEnb73XnP+yNl/SuR3/lzTSZHMTirMpMcXjWr0U5Mp/rnzmk/TsXkC2/iKEJ5TRG4DZ5KrP/C0RiVmkp+5I8zN1uh2vv9Vs+bzJ4947Y+bz6wl6ZIcv87ZaU2+6PwnoKdb7VYmrf9Z02MxCmNdmparbVJtrA4nA+e9LgIS6dzfvly7j+4XWIuPJp8iE9PbvkzJHYNabt/o5MP+535t/Hj95nr+PH7zHX8m/8B+RAnloz5pi4AAAAASUVORK5CYII=",
-                    policy: {
-                        type: "totp"
-                    },
-                    qrUrl: "http://localhost:8080/realms/myrealm/account/totp?mode=qr",
-                    otpCredentials: []
+    args: {
+        kcContext: {
+            totp: {
+                enabled: false,
+                totpSecretEncoded: "HE4W MSTC OBKU CY2M ONXF OV3Q NYYU I3SH",
+                totpSecret: "99fJbpUAcLsnWWpn1DnG",
+                manualUrl: "http://localhost:8080/realms/myrealm/account/totp?mode=manual",
+                totpSecretQrCode:
+                    "iVBORw0KGgoAAAANSUhEUgAAAPYAAAD2AQAAAADNaUdlAAACk0lEQVR4Xu2YQY6DMAxFjViw5AjcBC6GBBIXozfJEbpkger53wEKqOpmFvaikQYNeVRyHPvbiejXscp95jp+/D5zHT9+n7kO8qeIFDqKzjJo9dC1wUSPP7yG4IPq41lq9ZK+keLZSwXDGwMhOCZgdX4sBVD1qld+GYg/h6ScreBuIDo5FKfVM7Z8aWs9PB2E2/73DdOlwUrK9Ck+HDnzB7ziR8fjlD/OPI8pVQwCi899TkNw2M+tp9XSLFKPIq2UySIhBB906fCQTicFwiv1EUG6+d+bl4zPIYnUk5oIcS69/evPYStUp6P0dJhD/mhauijcth76mOsfw+GFrbfXKJx7LW2N15kijuWIMCYicLQOCEimDp1c0L8PzCLTs3/d+ZQLyl6VqeSIT9nz25szf2ZybHgC31yrXEQIbqaPjX0k9GqWy0N/nLkagsHWNXR0LZwsR357c0pjC6fm+meu5f6f6oszz/qj7GpYCdHf0LVH/gTgtJ/5bVavPJ9svwnBS9qaqwoHOh3G7Ln++HIIDgpKYpFW00dlkX7ruz836THBWQpzd23/xeDsFVroz15fRjsfMyaC8JX2Y8PZf+VIoKff+uTO6WSIUIfSkrl9/rbfnbPr30R8hnMtXA/98ea5lx4ZlSMgQlMsEnb73XnP+yNl/SuR3/lzTSZHMTirMpMcXjWr0U5Mp/rnzmk/TsXkC2/iKEJ5TRG4DZ5KrP/C0RiVmkp+5I8zN1uh2vv9Vs+bzJ4947Y+bz6wl6ZIcv87ZaU2+6PwnoKdb7VYmrf9Z02MxCmNdmparbVJtrA4nA+e9LgIS6dzfvly7j+4XWIuPJp8iE9PbvkzJHYNabt/o5MP+535t/Hj95nr+PH7zHX8m/8B+RAnloz5pi4AAAAASUVORK5CYII=",
+                policy: {
+                    type: "totp"
                 },
-                messagesPerField: {},
-                stateChecker: "ihTeSAMfNsobnPjYiktV8DY-5T4sVzVdrEZRdwfMm8Y",
-                realm: {
-                    userManagedAccessAllowed: true,
-                    internationalizationEnabled: false
-                },
-                url: {
-                    totpUrl: "http://localhost:8080/realms/myrealm/account/totp"
-                },
-                keycloakifyVersion: "9.6.1",
-                themeVersion: "1.0.10",
-                themeType: "account",
-                themeName: "keycloakify",
-                pageId: "totp.ftl"
-            }}
-        />
-    )
+                qrUrl: "http://localhost:8080/realms/myrealm/account/totp?mode=qr",
+                otpCredentials: []
+            },
+            messagesPerField: {},
+            stateChecker: "ihTeSAMfNsobnPjYiktV8DY-5T4sVzVdrEZRdwfMm8Y",
+            realm: {
+                userManagedAccessAllowed: true,
+                internationalizationEnabled: false
+            },
+            url: {
+                totpUrl: "http://localhost:8080/realms/myrealm/account/totp"
+            },
+            keycloakifyVersion: "9.6.1",
+            themeVersion: "1.0.10",
+            themeType: "account",
+            themeName: "keycloakify",
+            pageId: "totp.ftl"
+        }
+    }
 };
 
 export const WithTotpEnabled: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                totp: {
-                    enabled: true,
-                    totpSecretEncoded: "G55E MZKC JFUD MQLT MFIF EVSB JFLG M6SO",
-                    totpSecret: "7zFeBIh6AsaPRVAIVfzN",
-                    manualUrl: "http://localhost:8080/realms/myrealm/account/totp?mode=manual",
-                    supportedApplications: ["totpAppFreeOTPName", "totpAppMicrosoftAuthenticatorName", "totpAppGoogleName"],
-                    totpSecretQrCode:
-                        "iVBORw0KGgoAAAANSUhEUgAAAPYAAAD2AQAAAADNaUdlAAACo0lEQVR4Xu2YPY6DMBCFJ6JwyRF8k+RiSCBxsXATjkDpAmX2vTGBwErbbDFTZIps4s8rmfl9RvRPW+W6crYvv66c7cuvK2cjX0Tkho9yW/q5PHSc5QYA62PwXnWqmzrRSUdNL+mygRC8kzQZWhqVO1CRds3YHopnfUkzp2c7ZAY+GIdXywOb0qsdJMXiFn9serYrncxNv/PDkdfUzObk/eNaX368mnl1kML8RH1vFoGzargA1DM/VeWhOpf9+by5iL5Q0NaEUETslHiSIz+dOc4q0tqBrcg7IsnpnZ8BeLmjqjFa4Fps4vlR3484nFHH6OP8o1cTc4I/Q3D4Uqw1TjpkeHqc2R/Rjvb89OUUDAL/CpycOf/o6fUjP505/phrOf8wn+tolsxyD8GZnzyrJSScrNyEcXhHJwrBh2yj2fShPlFB2PQxn935aK1HIB1G1nczm8+P+nbmC7si+zell53a4i97fnhz5Gddxc9iSgLPpPifGn9vDqN0YBL0lpozdx7nd+dDHSiFXkV+NlZO85Efzvzda8yrwkylvlEbhxE4bTJpiCEIkWNHbxD/w/++fJMOVX8p5Q70F0V2EI4LsUWd+ov6Wtgu5aM/OXNIf6jWbKq6zmekA77t88WZr5lXO6vvWaj6kbNo4nv/ceaon0TpYPqrmNJhue/x9+ZKLchbO+cLPrb+aI09BLeob1en2nqkKsUYfOvatSGa/ircmD7i78rNmJoYzXwIKh228z3+ztzef+Cb6S/lSxoWOXM2CO/ZuvlqARtLvX8u1Ie6+d+bd/X9pdS3lrrF/8jPCPytv9AVIbfvddxE4iNFLKL+hH/xCNudKgTvGX/r33ars/y062gQjljfWN8cyKm+f2NPOvqTL//Lvvy6crYvv66c7d/8B/9RFjk6Tp30AAAAAElFTkSuQmCC",
-                    policy: {
-                        type: "totp",
-                        algorithm: "HmacSHA1"
-                    },
-                    qrUrl: "http://localhost:8080/realms/myrealm/account/totp?mode=qr",
-                    otpCredentials: [
-                        {
-                            id: "7afaaf7d-f2d5-44f5-a966-e5297f0b2b7a",
-                            userLabel: "mobile"
-                        }
-                    ]
+    args: {
+        kcContext: {
+            totp: {
+                enabled: true,
+                totpSecretEncoded: "G55E MZKC JFUD MQLT MFIF EVSB JFLG M6SO",
+                totpSecret: "7zFeBIh6AsaPRVAIVfzN",
+                manualUrl: "http://localhost:8080/realms/myrealm/account/totp?mode=manual",
+                supportedApplications: ["totpAppFreeOTPName", "totpAppMicrosoftAuthenticatorName", "totpAppGoogleName"],
+                totpSecretQrCode:
+                    "iVBORw0KGgoAAAANSUhEUgAAAPYAAAD2AQAAAADNaUdlAAACo0lEQVR4Xu2YPY6DMBCFJ6JwyRF8k+RiSCBxsXATjkDpAmX2vTGBwErbbDFTZIps4s8rmfl9RvRPW+W6crYvv66c7cuvK2cjX0Tkho9yW/q5PHSc5QYA62PwXnWqmzrRSUdNL+mygRC8kzQZWhqVO1CRds3YHopnfUkzp2c7ZAY+GIdXywOb0qsdJMXiFn9serYrncxNv/PDkdfUzObk/eNaX368mnl1kML8RH1vFoGzargA1DM/VeWhOpf9+by5iL5Q0NaEUETslHiSIz+dOc4q0tqBrcg7IsnpnZ8BeLmjqjFa4Fps4vlR3484nFHH6OP8o1cTc4I/Q3D4Uqw1TjpkeHqc2R/Rjvb89OUUDAL/CpycOf/o6fUjP505/phrOf8wn+tolsxyD8GZnzyrJSScrNyEcXhHJwrBh2yj2fShPlFB2PQxn935aK1HIB1G1nczm8+P+nbmC7si+zell53a4i97fnhz5Gddxc9iSgLPpPifGn9vDqN0YBL0lpozdx7nd+dDHSiFXkV+NlZO85Efzvzda8yrwkylvlEbhxE4bTJpiCEIkWNHbxD/w/++fJMOVX8p5Q70F0V2EI4LsUWd+ov6Wtgu5aM/OXNIf6jWbKq6zmekA77t88WZr5lXO6vvWaj6kbNo4nv/ceaon0TpYPqrmNJhue/x9+ZKLchbO+cLPrb+aI09BLeob1en2nqkKsUYfOvatSGa/ircmD7i78rNmJoYzXwIKh228z3+ztzef+Cb6S/lSxoWOXM2CO/ZuvlqARtLvX8u1Ie6+d+bd/X9pdS3lrrF/8jPCPytv9AVIbfvddxE4iNFLKL+hH/xCNudKgTvGX/r33ars/y062gQjljfWN8cyKm+f2NPOvqTL//Lvvy6crYvv66c7d/8B/9RFjk6Tp30AAAAAElFTkSuQmCC",
+                policy: {
+                    type: "totp",
+                    algorithm: "HmacSHA1"
                 },
-                message: {
-                    summary: "Mobile authenticator configured.",
-                    type: "success"
-                },
-                url: {
-                    totpUrl: "http://localhost:8080/realms/myrealm/account/totp"
-                },
-                messagesPerField: {},
-                stateChecker: "0UvyCNJHRJXmdahtRmn0tTPCU2nwLtWBUfPaaX1qb4g",
-                realm: {
-                    userManagedAccessAllowed: true,
-                    internationalizationEnabled: false
-                },
-                keycloakifyVersion: "9.6.1",
-                themeVersion: "1.0.10",
-                themeType: "account",
-                themeName: "keycloakify",
-                pageId: "totp.ftl"
-            }}
-        />
-    )
+                qrUrl: "http://localhost:8080/realms/myrealm/account/totp?mode=qr",
+                otpCredentials: [
+                    {
+                        id: "7afaaf7d-f2d5-44f5-a966-e5297f0b2b7a",
+                        userLabel: "mobile"
+                    }
+                ]
+            },
+            message: {
+                summary: "Mobile authenticator configured.",
+                type: "success"
+            },
+            url: {
+                totpUrl: "http://localhost:8080/realms/myrealm/account/totp"
+            },
+            messagesPerField: {},
+            stateChecker: "0UvyCNJHRJXmdahtRmn0tTPCU2nwLtWBUfPaaX1qb4g",
+            realm: {
+                userManagedAccessAllowed: true,
+                internationalizationEnabled: false
+            },
+            keycloakifyVersion: "9.6.1",
+            themeVersion: "1.0.10",
+            themeType: "account",
+            themeName: "keycloakify",
+            pageId: "totp.ftl"
+        }
+    }
 };
 
 export const WithManualMode: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                mode: "manual",
-                totp: {
-                    enabled: false,
-                    totpSecretEncoded: "KZ5H CYTW GBVV ASDE JRXG MMCK HAZU E6TX",
-                    totpSecret: "Vzqbv0kPHdLnf0J83Bzw",
-                    manualUrl: "http://localhost:8080/realms/myrealm/account/totp?mode=manual",
-                    totpSecretQrCode:
-                        "iVBORw0KGgoAAAANSUhEUgAAAPYAAAD2AQAAAADNaUdlAAACpklEQVR4Xu2YQa6rMAxFXTFgyBLYSbsxJJC6sb6dZAkdMkDNv8cBStHTm/yBM2ikIpqTgePY1w6W/xyLnWc+x5efZz7Hl59nPgf8aWaXPFl+2ZhbzfWaGPTT3yr4mPPPs8nty4ZeKxfzRQ6q4IO1P8zq0c/iffvqtIlLTfw5psxsK3f7JirjTHDqWpQ3T9fC/fytn2956u32bNJv8RHIyZ/n0MvJh8cpvwJ5GffkQaBNYPo2auCyv30YVmtitm4yu1qT5mtXCR9svsqXeih1/I1IbZHLKniTskxPOvCGSB3Wud2/0Vz+5YH9uHZAvzORUAlXaXmY9FHxyZuWI0L5sfs3lkt1vDTbtVtM8bmovrCT26o/0bxozVAWIY3IuTLpsvk3mDNeRv9QqrJWEp+25Xc01/uMVudHpySiE3PXklN1cLSm8yCgKmuWICUIxip4vqM6Y+kalNX3hJNtz+9orgOXQ60noZPrd/H5u74E86I/pfXXm/obXPvOr2juVW8o9nsTS77T5Ix18CZ71sh+qQ7n3+LzY32J5WptXt291Bdaf8tcVw76Hcvpqr31R3CUOri7Q79r4ap61+5O12XoT1leOrFK+HZ/asga/sr0tz5F85wozWq4aMKcP1DK3f54Ttfv+a0iqG1wCU2H/iGWl156IionQYWmngTpan84H9aGy+8nl7I8J5ejOnjP0SNCC/0/lVpydKyPwZz7u/Xef80ouaRHHt7PP5j74BJFfBpJ3vLp460/wdxtxX5KM6XPMvktJ6/7i+YjvfRS/Gs3za3218LJH5qwzKKf7fzd3fXwEWmkf5WTKS3JN1YRTxKhiY9IC6mzUKmP/g3knL8cqoeUiKvJL/EZyT1/sJ/vg+X7G07e7Q/mf40vP898ji8/z3yO/+b/ANUwOXCzdQgqAAAAAElFTkSuQmCC",
-                    policy: {
-                        type: "totp",
-                        algorithm: "HmacSHA1"
-                    },
-                    qrUrl: "http://localhost:8080/realms/myrealm/account/totp?mode=qr",
-                    otpCredentials: []
+    args: {
+        kcContext: {
+            mode: "manual",
+            totp: {
+                enabled: false,
+                totpSecretEncoded: "KZ5H CYTW GBVV ASDE JRXG MMCK HAZU E6TX",
+                totpSecret: "Vzqbv0kPHdLnf0J83Bzw",
+                manualUrl: "http://localhost:8080/realms/myrealm/account/totp?mode=manual",
+                totpSecretQrCode:
+                    "iVBORw0KGgoAAAANSUhEUgAAAPYAAAD2AQAAAADNaUdlAAACpklEQVR4Xu2YQa6rMAxFXTFgyBLYSbsxJJC6sb6dZAkdMkDNv8cBStHTm/yBM2ikIpqTgePY1w6W/xyLnWc+x5efZz7Hl59nPgf8aWaXPFl+2ZhbzfWaGPTT3yr4mPPPs8nty4ZeKxfzRQ6q4IO1P8zq0c/iffvqtIlLTfw5psxsK3f7JirjTHDqWpQ3T9fC/fytn2956u32bNJv8RHIyZ/n0MvJh8cpvwJ5GffkQaBNYPo2auCyv30YVmtitm4yu1qT5mtXCR9svsqXeih1/I1IbZHLKniTskxPOvCGSB3Wud2/0Vz+5YH9uHZAvzORUAlXaXmY9FHxyZuWI0L5sfs3lkt1vDTbtVtM8bmovrCT26o/0bxozVAWIY3IuTLpsvk3mDNeRv9QqrJWEp+25Xc01/uMVudHpySiE3PXklN1cLSm8yCgKmuWICUIxip4vqM6Y+kalNX3hJNtz+9orgOXQ60noZPrd/H5u74E86I/pfXXm/obXPvOr2juVW8o9nsTS77T5Ix18CZ71sh+qQ7n3+LzY32J5WptXt291Bdaf8tcVw76Hcvpqr31R3CUOri7Q79r4ap61+5O12XoT1leOrFK+HZ/asga/sr0tz5F85wozWq4aMKcP1DK3f54Ttfv+a0iqG1wCU2H/iGWl156IionQYWmngTpan84H9aGy+8nl7I8J5ejOnjP0SNCC/0/lVpydKyPwZz7u/Xef80ouaRHHt7PP5j74BJFfBpJ3vLp460/wdxtxX5KM6XPMvktJ6/7i+YjvfRS/Gs3za3218LJH5qwzKKf7fzd3fXwEWmkf5WTKS3JN1YRTxKhiY9IC6mzUKmP/g3knL8cqoeUiKvJL/EZyT1/sJ/vg+X7G07e7Q/mf40vP898ji8/z3yO/+b/ANUwOXCzdQgqAAAAAElFTkSuQmCC",
+                policy: {
+                    type: "totp",
+                    algorithm: "HmacSHA1"
                 },
-                messagesPerField: {},
-                stateChecker: "HiBl2ADzLwKwQS813LOEig1Ymm4xpEu_NacYtWJIuHU",
-                realm: {
-                    userManagedAccessAllowed: true,
-                    internationalizationEnabled: false
-                },
-                url: {
-                    totpUrl: "http://localhost:8080/realms/myrealm/account/totp?mode=manual"
-                },
-                keycloakifyVersion: "9.6.1",
-                themeVersion: "1.0.10",
-                themeType: "account",
-                themeName: "keycloakify",
-                pageId: "totp.ftl"
-            }}
-        />
-    )
+                qrUrl: "http://localhost:8080/realms/myrealm/account/totp?mode=qr",
+                otpCredentials: []
+            },
+            messagesPerField: {},
+            stateChecker: "HiBl2ADzLwKwQS813LOEig1Ymm4xpEu_NacYtWJIuHU",
+            realm: {
+                userManagedAccessAllowed: true,
+                internationalizationEnabled: false
+            },
+            url: {
+                totpUrl: "http://localhost:8080/realms/myrealm/account/totp?mode=manual"
+            },
+            keycloakifyVersion: "9.6.1",
+            themeVersion: "1.0.10",
+            themeType: "account",
+            themeName: "keycloakify",
+            pageId: "totp.ftl"
+        }
+    }
 };
 
 export const MoreThanOneTotpProviders: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                totp: {
-                    enabled: true,
-                    totpSecretEncoded: "G55E MZKC JFUD MQLT MFIF EVSB JFLG M6SO",
-                    totpSecret: "7zFeBIh6AsaPRVAIVfzN",
-                    manualUrl: "http://localhost:8080/realms/myrealm/account/totp?mode=manual",
-                    supportedApplications: ["totpAppFreeOTPName", "totpAppMicrosoftAuthenticatorName", "totpAppGoogleName"],
-                    totpSecretQrCode:
-                        "iVBORw0KGgoAAAANSUhEUgAAAPYAAAD2AQAAAADNaUdlAAACo0lEQVR4Xu2YPY6DMBCFJ6JwyRF8k+RiSCBxsXATjkDpAmX2vTGBwErbbDFTZIps4s8rmfl9RvRPW+W6crYvv66c7cuvK2cjX0Tkho9yW/q5PHSc5QYA62PwXnWqmzrRSUdNL+mygRC8kzQZWhqVO1CRds3YHopnfUkzp2c7ZAY+GIdXywOb0qsdJMXiFn9serYrncxNv/PDkdfUzObk/eNaX368mnl1kML8RH1vFoGzargA1DM/VeWhOpf9+by5iL5Q0NaEUETslHiSIz+dOc4q0tqBrcg7IsnpnZ8BeLmjqjFa4Fps4vlR3484nFHH6OP8o1cTc4I/Q3D4Uqw1TjpkeHqc2R/Rjvb89OUUDAL/CpycOf/o6fUjP505/phrOf8wn+tolsxyD8GZnzyrJSScrNyEcXhHJwrBh2yj2fShPlFB2PQxn935aK1HIB1G1nczm8+P+nbmC7si+zell53a4i97fnhz5Gddxc9iSgLPpPifGn9vDqN0YBL0lpozdx7nd+dDHSiFXkV+NlZO85Efzvzda8yrwkylvlEbhxE4bTJpiCEIkWNHbxD/w/++fJMOVX8p5Q70F0V2EI4LsUWd+ov6Wtgu5aM/OXNIf6jWbKq6zmekA77t88WZr5lXO6vvWaj6kbNo4nv/ceaon0TpYPqrmNJhue/x9+ZKLchbO+cLPrb+aI09BLeob1en2nqkKsUYfOvatSGa/ircmD7i78rNmJoYzXwIKh228z3+ztzef+Cb6S/lSxoWOXM2CO/ZuvlqARtLvX8u1Ie6+d+bd/X9pdS3lrrF/8jPCPytv9AVIbfvddxE4iNFLKL+hH/xCNudKgTvGX/r33ars/y062gQjljfWN8cyKm+f2NPOvqTL//Lvvy6crYvv66c7d/8B/9RFjk6Tp30AAAAAElFTkSuQmCC",
-                    policy: {
-                        type: "totp",
-                        algorithm: "HmacSHA1"
+    args: {
+        kcContext: {
+            totp: {
+                enabled: true,
+                totpSecretEncoded: "G55E MZKC JFUD MQLT MFIF EVSB JFLG M6SO",
+                totpSecret: "7zFeBIh6AsaPRVAIVfzN",
+                manualUrl: "http://localhost:8080/realms/myrealm/account/totp?mode=manual",
+                supportedApplications: ["totpAppFreeOTPName", "totpAppMicrosoftAuthenticatorName", "totpAppGoogleName"],
+                totpSecretQrCode:
+                    "iVBORw0KGgoAAAANSUhEUgAAAPYAAAD2AQAAAADNaUdlAAACo0lEQVR4Xu2YPY6DMBCFJ6JwyRF8k+RiSCBxsXATjkDpAmX2vTGBwErbbDFTZIps4s8rmfl9RvRPW+W6crYvv66c7cuvK2cjX0Tkho9yW/q5PHSc5QYA62PwXnWqmzrRSUdNL+mygRC8kzQZWhqVO1CRds3YHopnfUkzp2c7ZAY+GIdXywOb0qsdJMXiFn9serYrncxNv/PDkdfUzObk/eNaX368mnl1kML8RH1vFoGzargA1DM/VeWhOpf9+by5iL5Q0NaEUETslHiSIz+dOc4q0tqBrcg7IsnpnZ8BeLmjqjFa4Fps4vlR3484nFHH6OP8o1cTc4I/Q3D4Uqw1TjpkeHqc2R/Rjvb89OUUDAL/CpycOf/o6fUjP505/phrOf8wn+tolsxyD8GZnzyrJSScrNyEcXhHJwrBh2yj2fShPlFB2PQxn935aK1HIB1G1nczm8+P+nbmC7si+zell53a4i97fnhz5Gddxc9iSgLPpPifGn9vDqN0YBL0lpozdx7nd+dDHSiFXkV+NlZO85Efzvzda8yrwkylvlEbhxE4bTJpiCEIkWNHbxD/w/++fJMOVX8p5Q70F0V2EI4LsUWd+ov6Wtgu5aM/OXNIf6jWbKq6zmekA77t88WZr5lXO6vvWaj6kbNo4nv/ceaon0TpYPqrmNJhue/x9+ZKLchbO+cLPrb+aI09BLeob1en2nqkKsUYfOvatSGa/ircmD7i78rNmJoYzXwIKh228z3+ztzef+Cb6S/lSxoWOXM2CO/ZuvlqARtLvX8u1Ie6+d+bd/X9pdS3lrrF/8jPCPytv9AVIbfvddxE4iNFLKL+hH/xCNudKgTvGX/r33ars/y062gQjljfWN8cyKm+f2NPOvqTL//Lvvy6crYvv66c7d/8B/9RFjk6Tp30AAAAAElFTkSuQmCC",
+                policy: {
+                    type: "totp",
+                    algorithm: "HmacSHA1"
+                },
+                qrUrl: "http://localhost:8080/realms/myrealm/account/totp?mode=qr",
+                otpCredentials: [
+                    {
+                        id: "7afaaf7d-f2d5-44f5-a966-e5297f0b2b7a",
+                        userLabel: "Samsung S23"
                     },
-                    qrUrl: "http://localhost:8080/realms/myrealm/account/totp?mode=qr",
-                    otpCredentials: [
-                        {
-                            id: "7afaaf7d-f2d5-44f5-a966-e5297f0b2b7a",
-                            userLabel: "Samsung S23"
-                        },
-                        {
-                            id: "fbe22500-d979-45a3-9666-84c99e27958e",
-                            userLabel: "Apple Iphone 15"
-                        }
-                    ]
-                },
-                url: {
-                    totpUrl: "http://localhost:8080/realms/myrealm/account/totp"
-                },
-                messagesPerField: {},
-                stateChecker: "0UvyCNJHRJXmdahtRmn0tTPCU2nwLtWBUfPaaX1qb4g",
-                realm: {
-                    userManagedAccessAllowed: true,
-                    internationalizationEnabled: false
-                },
-                keycloakifyVersion: "9.6.1",
-                themeVersion: "1.0.10",
-                themeType: "account",
-                themeName: "keycloakify",
-                pageId: "totp.ftl"
-            }}
-        />
-    )
+                    {
+                        id: "fbe22500-d979-45a3-9666-84c99e27958e",
+                        userLabel: "Apple Iphone 15"
+                    }
+                ]
+            },
+            url: {
+                totpUrl: "http://localhost:8080/realms/myrealm/account/totp"
+            },
+            messagesPerField: {},
+            stateChecker: "0UvyCNJHRJXmdahtRmn0tTPCU2nwLtWBUfPaaX1qb4g",
+            realm: {
+                userManagedAccessAllowed: true,
+                internationalizationEnabled: false
+            },
+            keycloakifyVersion: "9.6.1",
+            themeVersion: "1.0.10",
+            themeType: "account",
+            themeName: "keycloakify",
+            pageId: "totp.ftl"
+        }
+    }
 };
 
 // TOTP Enabled but No Existing OTP Credentials
 export const TotpEnabledNoOtpCredentials: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                totp: {
-                    enabled: true,
-                    totpSecretEncoded: "HE4W MSTC OBKU CY2M",
-                    otpCredentials: [] // No OTP Credentials
-                },
-                stateChecker: "stateChecker123",
-                url: {
-                    totpUrl: "http://localhost:8080/realms/myrealm/account/totp"
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            totp: {
+                enabled: true,
+                totpSecretEncoded: "HE4W MSTC OBKU CY2M",
+                otpCredentials: [] // No OTP Credentials
+            },
+            stateChecker: "stateChecker123",
+            url: {
+                totpUrl: "http://localhost:8080/realms/myrealm/account/totp"
+            }
+        }
+    }
 };
 
 // Manual Mode TOTP without Scanning
 export const ManualModeTotp: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                mode: "manual", // Manual mode
-                totp: {
-                    enabled: false,
-                    totpSecretEncoded: "HE4W MSTC OBKU CY2M",
-                    otpCredentials: []
-                },
-                stateChecker: "stateChecker123",
-                url: {
-                    totpUrl: "http://localhost:8080/realms/myrealm/account/totp"
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            mode: "manual", // Manual mode
+            totp: {
+                enabled: false,
+                totpSecretEncoded: "HE4W MSTC OBKU CY2M",
+                otpCredentials: []
+            },
+            stateChecker: "stateChecker123",
+            url: {
+                totpUrl: "http://localhost:8080/realms/myrealm/account/totp"
+            }
+        }
+    }
 };
 
 // Multiple OTP Devices Scenario
 export const MultipleOtpDevices: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                totp: {
-                    enabled: true,
-                    totpSecretEncoded: "G55E MZKC JFUD",
-                    otpCredentials: [
-                        { id: "1", userLabel: "Phone 1" },
-                        { id: "2", userLabel: "Tablet" }
-                    ]
-                },
-                stateChecker: "stateChecker123",
-                url: {
-                    totpUrl: "http://localhost:8080/realms/myrealm/account/totp"
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            totp: {
+                enabled: true,
+                totpSecretEncoded: "G55E MZKC JFUD",
+                otpCredentials: [
+                    { id: "1", userLabel: "Phone 1" },
+                    { id: "2", userLabel: "Tablet" }
+                ]
+            },
+            stateChecker: "stateChecker123",
+            url: {
+                totpUrl: "http://localhost:8080/realms/myrealm/account/totp"
+            }
+        }
+    }
 };

--- a/stories/login/pages/Code.stories.tsx
+++ b/stories/login/pages/Code.stories.tsx
@@ -13,45 +13,37 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-    render: () => <KcPageStory />
-};
+export const Default: Story = {};
 export const WithErrorCode: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                code: {
-                    success: false,
-                    error: "Failed to generate code"
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            code: {
+                success: false,
+                error: "Failed to generate code"
+            }
+        }
+    }
 };
 export const WithFrenchLanguage: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                locale: {
-                    currentLanguageTag: "fr"
-                },
-                code: {
-                    success: true,
-                    code: "XYZ789"
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            locale: {
+                currentLanguageTag: "fr"
+            },
+            code: {
+                success: true,
+                code: "XYZ789"
+            }
+        }
+    }
 };
 export const WithHtmlErrorMessage: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                code: {
-                    success: false,
-                    error: "Something went wrong. <a href='https://example.com'>Try again</a>"
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            code: {
+                success: false,
+                error: "Something went wrong. <a href='https://example.com'>Try again</a>"
+            }
+        }
+    }
 };

--- a/stories/login/pages/DeleteAccountConfirm.stories.tsx
+++ b/stories/login/pages/DeleteAccountConfirm.stories.tsx
@@ -13,36 +13,28 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-    render: () => <KcPageStory />
-};
+export const Default: Story = {};
 export const WithAIAFlow: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                triggered_from_aia: true,
-                url: { loginAction: "/login-action" }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            triggered_from_aia: true,
+            url: { loginAction: "/login-action" }
+        }
+    }
 };
 export const WithoutAIAFlow: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                triggered_from_aia: false,
-                url: { loginAction: "/login-action" }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            triggered_from_aia: false,
+            url: { loginAction: "/login-action" }
+        }
+    }
 };
 export const WithCustomButtonStyle: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                triggered_from_aia: true,
-                url: { loginAction: "/login-action" }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            triggered_from_aia: true,
+            url: { loginAction: "/login-action" }
+        }
+    }
 };

--- a/stories/login/pages/DeleteCredential.stories.tsx
+++ b/stories/login/pages/DeleteCredential.stories.tsx
@@ -13,16 +13,12 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-    render: () => <KcPageStory />
-};
+export const Default: Story = {};
 export const WithCustomCredentialLabel: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                credentialLabel: "Test Credential",
-                url: { loginAction: "/login-action" }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            credentialLabel: "Test Credential",
+            url: { loginAction: "/login-action" }
+        }
+    }
 };

--- a/stories/login/pages/Error.stories.tsx
+++ b/stories/login/pages/Error.stories.tsx
@@ -13,51 +13,41 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-    render: () => <KcPageStory />
-};
+export const Default: Story = {};
 
 export const WithAnotherMessage: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                message: { summary: "With another error message" }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            message: { summary: "With another error message" }
+        }
+    }
 };
 
 export const WithHtmlErrorMessage: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                message: {
-                    summary: "<strong>Error:</strong> Something went wrong. <a href='https://example.com'>Go back</a>"
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            message: {
+                summary: "<strong>Error:</strong> Something went wrong. <a href='https://example.com'>Go back</a>"
+            }
+        }
+    }
 };
 export const FrenchError: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                locale: { currentLanguageTag: "fr" },
-                message: { summary: "Une erreur s'est produite" }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            locale: { currentLanguageTag: "fr" },
+            message: { summary: "Une erreur s'est produite" }
+        }
+    }
 };
 export const WithSkipLink: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                message: { summary: "An error occurred" },
-                skipLink: true,
-                client: {
-                    baseUrl: "https://example.com"
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            message: { summary: "An error occurred" },
+            skipLink: true,
+            client: {
+                baseUrl: "https://example.com"
+            }
+        }
+    }
 };

--- a/stories/login/pages/FrontchannelLogout.stories.tsx
+++ b/stories/login/pages/FrontchannelLogout.stories.tsx
@@ -13,17 +13,13 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-    render: () => <KcPageStory />
-};
+export const Default: Story = {};
 export const WithoutRedirectUrl: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                logout: {
-                    clients: []
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            logout: {
+                clients: []
+            }
+        }
+    }
 };

--- a/stories/login/pages/IdpReviewUserProfile.stories.tsx
+++ b/stories/login/pages/IdpReviewUserProfile.stories.tsx
@@ -13,50 +13,42 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-    render: () => <KcPageStory />
-};
+export const Default: Story = {};
 export const WithFormValidationErrors: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                messagesPerField: {
-                    existsError: (fieldName: string) => ["email", "firstName"].includes(fieldName),
-                    get: (fieldName: string) => {
-                        if (fieldName === "email") return "Invalid email format.";
-                        if (fieldName === "firstName") return "First name is required.";
-                    }
+    args: {
+        kcContext: {
+            messagesPerField: {
+                existsError: (fieldName: string) => ["email", "firstName"].includes(fieldName),
+                get: (fieldName: string) => {
+                    if (fieldName === "email") return "Invalid email format.";
+                    if (fieldName === "firstName") return "First name is required.";
                 }
-            }}
-        />
-    )
+            }
+        }
+    }
 };
 export const WithReadOnlyFields: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                profile: {
-                    attributesByName: {
-                        email: { value: "jane.doe@example.com", readOnly: true },
-                        firstName: { value: "Jane", readOnly: false }
-                    }
+    args: {
+        kcContext: {
+            profile: {
+                attributesByName: {
+                    email: { value: "jane.doe@example.com", readOnly: true },
+                    firstName: { value: "Jane", readOnly: false }
                 }
-            }}
-        />
-    )
+            }
+        }
+    }
 };
 export const WithPrefilledFormFields: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                profile: {
-                    attributesByName: {
-                        firstName: { value: "Jane" },
-                        lastName: { value: "Doe" },
-                        email: { value: "jane.doe@example.com" }
-                    }
+    args: {
+        kcContext: {
+            profile: {
+                attributesByName: {
+                    firstName: { value: "Jane" },
+                    lastName: { value: "Doe" },
+                    email: { value: "jane.doe@example.com" }
                 }
-            }}
-        />
-    )
+            }
+        }
+    }
 };

--- a/stories/login/pages/Info.stories.tsx
+++ b/stories/login/pages/Info.stories.tsx
@@ -14,83 +14,69 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                message: {
-                    summary: "Server info message"
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            message: {
+                summary: "Server info message"
+            }
+        }
+    }
 };
 
 export const WithLinkBack: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                message: {
-                    summary: "Server message"
-                },
-                actionUri: undefined
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            message: {
+                summary: "Server message"
+            },
+            actionUri: undefined
+        }
+    }
 };
 
 export const WithRequiredActions: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                message: {
-                    summary: "Required actions: "
-                },
-                requiredActions: ["CONFIGURE_TOTP", "UPDATE_PROFILE", "VERIFY_EMAIL", "CUSTOM_ACTION"],
-                "x-keycloakify": {
-                    messages: {
-                        "requiredAction.CUSTOM_ACTION": "Custom action"
-                    }
+    args: {
+        kcContext: {
+            message: {
+                summary: "Required actions: "
+            },
+            requiredActions: ["CONFIGURE_TOTP", "UPDATE_PROFILE", "VERIFY_EMAIL", "CUSTOM_ACTION"],
+            "x-keycloakify": {
+                messages: {
+                    "requiredAction.CUSTOM_ACTION": "Custom action"
                 }
-            }}
-        />
-    )
+            }
+        }
+    }
 };
 export const WithPageRedirect: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                message: { summary: "You will be redirected shortly." },
-                pageRedirectUri: "https://example.com"
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            message: { summary: "You will be redirected shortly." },
+            pageRedirectUri: "https://example.com"
+        }
+    }
 };
 export const WithoutClientBaseUrl: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                message: { summary: "No client base URL defined." },
-                client: { baseUrl: undefined }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            message: { summary: "No client base URL defined." },
+            client: { baseUrl: undefined }
+        }
+    }
 };
 export const WithMessageHeader: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                messageHeader: "Important Notice",
-                message: { summary: "This is an important message." }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            messageHeader: "Important Notice",
+            message: { summary: "This is an important message." }
+        }
+    }
 };
 export const WithAdvancedMessage: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                message: { summary: "Please take note of this <strong>important</strong> information." }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            message: { summary: "Please take note of this <strong>important</strong> information." }
+        }
+    }
 };

--- a/stories/login/pages/Login.stories.tsx
+++ b/stories/login/pages/Login.stories.tsx
@@ -13,223 +13,201 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-    render: () => <KcPageStory />
-};
+export const Default: Story = {};
 
 export const WithInvalidCredential: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                login: {
-                    username: "johndoe"
+    args: {
+        kcContext: {
+            login: {
+                username: "johndoe"
+            },
+            messagesPerField: {
+                // NOTE: The other functions of messagesPerField are derived from get() and
+                // existsError() so they are the only ones that need to mock.
+                existsError: (fieldName: string, ...otherFieldNames: string[]) => {
+                    const fieldNames = [fieldName, ...otherFieldNames];
+                    return fieldNames.includes("username") || fieldNames.includes("password");
                 },
-                messagesPerField: {
-                    // NOTE: The other functions of messagesPerField are derived from get() and
-                    // existsError() so they are the only ones that need to mock.
-                    existsError: (fieldName: string, ...otherFieldNames: string[]) => {
-                        const fieldNames = [fieldName, ...otherFieldNames];
-                        return fieldNames.includes("username") || fieldNames.includes("password");
-                    },
-                    get: (fieldName: string) => {
-                        if (fieldName === "username" || fieldName === "password") {
-                            return "Invalid username or password.";
-                        }
-                        return "";
+                get: (fieldName: string) => {
+                    if (fieldName === "username" || fieldName === "password") {
+                        return "Invalid username or password.";
                     }
+                    return "";
                 }
-            }}
-        />
-    )
+            }
+        }
+    }
 };
 
 export const WithoutRegistration: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                realm: { registrationAllowed: false }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            realm: { registrationAllowed: false }
+        }
+    }
 };
 
 export const WithoutRememberMe: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                realm: { rememberMe: false }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            realm: { rememberMe: false }
+        }
+    }
 };
 
 export const WithoutPasswordReset: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                realm: { resetPasswordAllowed: false }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            realm: { resetPasswordAllowed: false }
+        }
+    }
 };
 
 export const WithEmailAsUsername: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                realm: { loginWithEmailAllowed: false }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            realm: { loginWithEmailAllowed: false }
+        }
+    }
 };
 
 export const WithPresetUsername: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                login: { username: "max.mustermann@mail.com" }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            login: { username: "max.mustermann@mail.com" }
+        }
+    }
 };
 
 export const WithImmutablePresetUsername: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                auth: {
-                    attemptedUsername: "max.mustermann@mail.com",
-                    showUsername: true
-                },
-                usernameHidden: true,
-                message: {
-                    type: "info",
-                    summary: "Please re-authenticate to continue"
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            auth: {
+                attemptedUsername: "max.mustermann@mail.com",
+                showUsername: true
+            },
+            usernameHidden: true,
+            message: {
+                type: "info",
+                summary: "Please re-authenticate to continue"
+            }
+        }
+    }
 };
 
 export const WithSocialProviders: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                social: {
-                    displayInfo: true,
-                    providers: [
-                        {
-                            loginUrl: "google",
-                            alias: "google",
-                            providerId: "google",
-                            displayName: "Google",
-                            iconClasses: "fa fa-google"
-                        },
-                        {
-                            loginUrl: "microsoft",
-                            alias: "microsoft",
-                            providerId: "microsoft",
-                            displayName: "Microsoft",
-                            iconClasses: "fa fa-windows"
-                        },
-                        {
-                            loginUrl: "facebook",
-                            alias: "facebook",
-                            providerId: "facebook",
-                            displayName: "Facebook",
-                            iconClasses: "fa fa-facebook"
-                        },
-                        {
-                            loginUrl: "instagram",
-                            alias: "instagram",
-                            providerId: "instagram",
-                            displayName: "Instagram",
-                            iconClasses: "fa fa-instagram"
-                        },
-                        {
-                            loginUrl: "twitter",
-                            alias: "twitter",
-                            providerId: "twitter",
-                            displayName: "Twitter",
-                            iconClasses: "fa fa-twitter"
-                        },
-                        {
-                            loginUrl: "linkedin",
-                            alias: "linkedin",
-                            providerId: "linkedin",
-                            displayName: "LinkedIn",
-                            iconClasses: "fa fa-linkedin"
-                        },
-                        {
-                            loginUrl: "stackoverflow",
-                            alias: "stackoverflow",
-                            providerId: "stackoverflow",
-                            displayName: "Stackoverflow",
-                            iconClasses: "fa fa-stack-overflow"
-                        },
-                        {
-                            loginUrl: "github",
-                            alias: "github",
-                            providerId: "github",
-                            displayName: "Github",
-                            iconClasses: "fa fa-github"
-                        },
-                        {
-                            loginUrl: "gitlab",
-                            alias: "gitlab",
-                            providerId: "gitlab",
-                            displayName: "Gitlab",
-                            iconClasses: "fa fa-gitlab"
-                        },
-                        {
-                            loginUrl: "bitbucket",
-                            alias: "bitbucket",
-                            providerId: "bitbucket",
-                            displayName: "Bitbucket",
-                            iconClasses: "fa fa-bitbucket"
-                        },
-                        {
-                            loginUrl: "paypal",
-                            alias: "paypal",
-                            providerId: "paypal",
-                            displayName: "PayPal",
-                            iconClasses: "fa fa-paypal"
-                        },
-                        {
-                            loginUrl: "openshift",
-                            alias: "openshift",
-                            providerId: "openshift",
-                            displayName: "OpenShift",
-                            iconClasses: "fa fa-cloud"
-                        }
-                    ]
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            social: {
+                displayInfo: true,
+                providers: [
+                    {
+                        loginUrl: "google",
+                        alias: "google",
+                        providerId: "google",
+                        displayName: "Google",
+                        iconClasses: "fa fa-google"
+                    },
+                    {
+                        loginUrl: "microsoft",
+                        alias: "microsoft",
+                        providerId: "microsoft",
+                        displayName: "Microsoft",
+                        iconClasses: "fa fa-windows"
+                    },
+                    {
+                        loginUrl: "facebook",
+                        alias: "facebook",
+                        providerId: "facebook",
+                        displayName: "Facebook",
+                        iconClasses: "fa fa-facebook"
+                    },
+                    {
+                        loginUrl: "instagram",
+                        alias: "instagram",
+                        providerId: "instagram",
+                        displayName: "Instagram",
+                        iconClasses: "fa fa-instagram"
+                    },
+                    {
+                        loginUrl: "twitter",
+                        alias: "twitter",
+                        providerId: "twitter",
+                        displayName: "Twitter",
+                        iconClasses: "fa fa-twitter"
+                    },
+                    {
+                        loginUrl: "linkedin",
+                        alias: "linkedin",
+                        providerId: "linkedin",
+                        displayName: "LinkedIn",
+                        iconClasses: "fa fa-linkedin"
+                    },
+                    {
+                        loginUrl: "stackoverflow",
+                        alias: "stackoverflow",
+                        providerId: "stackoverflow",
+                        displayName: "Stackoverflow",
+                        iconClasses: "fa fa-stack-overflow"
+                    },
+                    {
+                        loginUrl: "github",
+                        alias: "github",
+                        providerId: "github",
+                        displayName: "Github",
+                        iconClasses: "fa fa-github"
+                    },
+                    {
+                        loginUrl: "gitlab",
+                        alias: "gitlab",
+                        providerId: "gitlab",
+                        displayName: "Gitlab",
+                        iconClasses: "fa fa-gitlab"
+                    },
+                    {
+                        loginUrl: "bitbucket",
+                        alias: "bitbucket",
+                        providerId: "bitbucket",
+                        displayName: "Bitbucket",
+                        iconClasses: "fa fa-bitbucket"
+                    },
+                    {
+                        loginUrl: "paypal",
+                        alias: "paypal",
+                        providerId: "paypal",
+                        displayName: "PayPal",
+                        iconClasses: "fa fa-paypal"
+                    },
+                    {
+                        loginUrl: "openshift",
+                        alias: "openshift",
+                        providerId: "openshift",
+                        displayName: "OpenShift",
+                        iconClasses: "fa fa-cloud"
+                    }
+                ]
+            }
+        }
+    }
 };
 
 export const WithoutPasswordField: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                realm: { password: false }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            realm: { password: false }
+        }
+    }
 };
 
 export const WithErrorMessage: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                message: {
-                    summary: "The time allotted for the connection has elapsed.<br/>The login process will restart from the beginning.",
-                    type: "error"
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            message: {
+                summary: "The time allotted for the connection has elapsed.<br/>The login process will restart from the beginning.",
+                type: "error"
+            }
+        }
+    }
 };
 
 export const WithOneSocialProvider: Story = {

--- a/stories/login/pages/LoginConfigTotp.stories.tsx
+++ b/stories/login/pages/LoginConfigTotp.stories.tsx
@@ -13,52 +13,42 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-    render: () => <KcPageStory />
-};
+export const Default: Story = {};
 
 export const WithManualSetUp: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                mode: "manual"
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            mode: "manual"
+        }
+    }
 };
 
 export const WithError: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                messagesPerField: {
-                    get: (fieldName: string) => (fieldName === "totp" ? "Invalid TOTP" : undefined),
-                    exists: (fieldName: string) => fieldName === "totp",
-                    existsError: (fieldName: string) => fieldName === "totp",
-                    printIfExists: <T,>(fieldName: string, x: T) => (fieldName === "totp" ? x : undefined)
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            messagesPerField: {
+                get: (fieldName: string) => (fieldName === "totp" ? "Invalid TOTP" : undefined),
+                exists: (fieldName: string) => fieldName === "totp",
+                existsError: (fieldName: string) => fieldName === "totp",
+                printIfExists: <T,>(fieldName: string, x: T) => (fieldName === "totp" ? x : undefined)
+            }
+        }
+    }
 };
 export const WithAppInitiatedAction: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                isAppInitiatedAction: true
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            isAppInitiatedAction: true
+        }
+    }
 };
 
 export const WithPreFilledUserLabel: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                totp: {
-                    otpCredentials: [{ userLabel: "MyDevice" }]
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            totp: {
+                otpCredentials: [{ userLabel: "MyDevice" }]
+            }
+        }
+    }
 };

--- a/stories/login/pages/LoginDeviceVerifyUserCode.stories.tsx
+++ b/stories/login/pages/LoginDeviceVerifyUserCode.stories.tsx
@@ -13,6 +13,4 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-    render: () => <KcPageStory />
-};
+export const Default: Story = {};

--- a/stories/login/pages/LoginIdpLinkConfirm.stories.tsx
+++ b/stories/login/pages/LoginIdpLinkConfirm.stories.tsx
@@ -38,18 +38,16 @@ export const Default: Story = {
  * - Key Aspect: Verifies that the component can display error messages during form submission failure, ensuring proper error handling.
  */
 export const WithFormSubmissionError: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                ...mockKcContext,
-                url: {
-                    loginAction: "/error"
-                },
-                message: {
-                    type: "error",
-                    summary: "An error occurred during form submission."
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            ...mockKcContext,
+            url: {
+                loginAction: "/error"
+            },
+            message: {
+                type: "error",
+                summary: "An error occurred during form submission."
+            }
+        }
+    }
 };

--- a/stories/login/pages/LoginIdpLinkConfirmOverride.stories.tsx
+++ b/stories/login/pages/LoginIdpLinkConfirmOverride.stories.tsx
@@ -13,6 +13,4 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-    render: () => <KcPageStory />
-};
+export const Default: Story = {};

--- a/stories/login/pages/LoginIdpLinkEmail.stories.tsx
+++ b/stories/login/pages/LoginIdpLinkEmail.stories.tsx
@@ -44,20 +44,18 @@ export const Default: Story = {
  * - Key Aspect: Ensures the correct identity provider alias ("Google") and broker context (user info) are displayed in the email linking instructions.
  */
 export const WithIdpAlias: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                ...mockKcContext,
-                idpAlias: "Google",
-                brokerContext: {
-                    username: "john.doe"
-                },
-                realm: {
-                    displayName: "MyRealm"
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            ...mockKcContext,
+            idpAlias: "Google",
+            brokerContext: {
+                username: "john.doe"
+            },
+            realm: {
+                displayName: "MyRealm"
+            }
+        }
+    }
 };
 
 /**
@@ -67,20 +65,18 @@ export const WithIdpAlias: Story = {
  * - Key Aspect: Ensures that custom realm display names are rendered correctly alongside the idpAlias and broker context.
  */
 export const WithCustomRealmDisplayName: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                ...mockKcContext,
-                idpAlias: "Facebook",
-                brokerContext: {
-                    username: "jane.doe"
-                },
-                realm: {
-                    displayName: "CUSTOM REALM DISPLAY NAME"
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            ...mockKcContext,
+            idpAlias: "Facebook",
+            brokerContext: {
+                username: "jane.doe"
+            },
+            realm: {
+                displayName: "CUSTOM REALM DISPLAY NAME"
+            }
+        }
+    }
 };
 
 /**
@@ -90,18 +86,16 @@ export const WithCustomRealmDisplayName: Story = {
  * - Key Aspect: Verifies that the component can display error messages during form submission failure, ensuring proper error handling.
  */
 export const WithFormSubmissionError: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                ...mockKcContext,
-                url: {
-                    loginAction: "/error"
-                },
-                message: {
-                    type: "error",
-                    summary: "An error occurred during form submission."
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            ...mockKcContext,
+            url: {
+                loginAction: "/error"
+            },
+            message: {
+                type: "error",
+                summary: "An error occurred during form submission."
+            }
+        }
+    }
 };

--- a/stories/login/pages/LoginOauth2DeviceVerifyUserCode.stories.tsx
+++ b/stories/login/pages/LoginOauth2DeviceVerifyUserCode.stories.tsx
@@ -13,9 +13,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-    render: () => <KcPageStory />
-};
+export const Default: Story = {};
 
 /**
  * WithErrorMessage:
@@ -24,19 +22,17 @@ export const Default: Story = {
  * - Key Aspect: Ensures the error message is properly shown when the user enters an invalid code.
  */
 export const WithErrorMessage: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                url: {
-                    oauth2DeviceVerificationAction: "/mock-oauth2-device-verification"
-                },
-                message: {
-                    summary: "The user code you entered is invalid. Please try again.",
-                    type: "error"
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            url: {
+                oauth2DeviceVerificationAction: "/mock-oauth2-device-verification"
+            },
+            message: {
+                summary: "The user code you entered is invalid. Please try again.",
+                type: "error"
+            }
+        }
+    }
 };
 
 /**
@@ -46,17 +42,15 @@ export const WithErrorMessage: Story = {
  * - Key Aspect: Ensures the form displays validation errors when the field is left empty.
  */
 export const WithEmptyInputField: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                url: {
-                    oauth2DeviceVerificationAction: "/mock-oauth2-device-verification"
-                },
-                message: {
-                    summary: "User code cannot be empty. Please enter a valid code.",
-                    type: "error"
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            url: {
+                oauth2DeviceVerificationAction: "/mock-oauth2-device-verification"
+            },
+            message: {
+                summary: "User code cannot be empty. Please enter a valid code.",
+                type: "error"
+            }
+        }
+    }
 };

--- a/stories/login/pages/LoginOauthGrant.stories.tsx
+++ b/stories/login/pages/LoginOauthGrant.stories.tsx
@@ -49,17 +49,15 @@ export const Default: Story = {
  * - Key Aspect: Ensures the component renders correctly when there are no requested scopes.
  */
 export const WithoutScopes: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                ...mockKcContext,
-                oauth: {
-                    ...mockKcContext.oauth,
-                    clientScopesRequested: []
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            ...mockKcContext,
+            oauth: {
+                ...mockKcContext.oauth,
+                clientScopesRequested: []
+            }
+        }
+    }
 };
 
 /**
@@ -69,18 +67,16 @@ export const WithoutScopes: Story = {
  * - Key Aspect: Ensures that the component can display error messages when form submission fails.
  */
 export const WithFormSubmissionError: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                ...mockKcContext,
-                url: {
-                    oauthAction: "/error"
-                },
-                message: {
-                    type: "error",
-                    summary: "An error occurred during form submission."
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            ...mockKcContext,
+            url: {
+                oauthAction: "/error"
+            },
+            message: {
+                type: "error",
+                summary: "An error occurred during form submission."
+            }
+        }
+    }
 };

--- a/stories/login/pages/LoginOtp.stories.tsx
+++ b/stories/login/pages/LoginOtp.stories.tsx
@@ -13,9 +13,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-    render: () => <KcPageStory />
-};
+export const Default: Story = {};
 
 /**
  * MultipleOtpCredentials:
@@ -24,29 +22,27 @@ export const Default: Story = {
  * - Key Aspect: Ensures that multiple OTP credentials are listed and selectable, and the correct credential is selected by default.
  */
 export const MultipleOtpCredentials: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                otpLogin: {
-                    userOtpCredentials: [
-                        { id: "credential1", userLabel: "Device 1" },
-                        { id: "credential2", userLabel: "Device 2" },
-                        { id: "credential2", userLabel: "Device 3" },
-                        { id: "credential2", userLabel: "Device 4" },
-                        { id: "credential2", userLabel: "Device 5" },
-                        { id: "credential2", userLabel: "Device 6" }
-                    ],
-                    selectedCredentialId: "credential1"
-                },
-                url: {
-                    loginAction: "/login-action"
-                },
-                messagesPerField: {
-                    existsError: () => false
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            otpLogin: {
+                userOtpCredentials: [
+                    { id: "credential1", userLabel: "Device 1" },
+                    { id: "credential2", userLabel: "Device 2" },
+                    { id: "credential2", userLabel: "Device 3" },
+                    { id: "credential2", userLabel: "Device 4" },
+                    { id: "credential2", userLabel: "Device 5" },
+                    { id: "credential2", userLabel: "Device 6" }
+                ],
+                selectedCredentialId: "credential1"
+            },
+            url: {
+                loginAction: "/login-action"
+            },
+            messagesPerField: {
+                existsError: () => false
+            }
+        }
+    }
 };
 
 /**
@@ -56,22 +52,20 @@ export const MultipleOtpCredentials: Story = {
  * - Key Aspect: Ensures that the OTP input displays error messages correctly and the error is visible.
  */
 export const WithOtpError: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                otpLogin: {
-                    userOtpCredentials: []
-                },
-                url: {
-                    loginAction: "/login-action"
-                },
-                messagesPerField: {
-                    existsError: (field: string) => field === "totp",
-                    get: () => "Invalid OTP code"
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            otpLogin: {
+                userOtpCredentials: []
+            },
+            url: {
+                loginAction: "/login-action"
+            },
+            messagesPerField: {
+                existsError: (field: string) => field === "totp",
+                get: () => "Invalid OTP code"
+            }
+        }
+    }
 };
 
 /**
@@ -81,21 +75,19 @@ export const WithOtpError: Story = {
  * - Key Aspect: Ensures that the component handles cases where there are no user OTP credentials, and the user is only prompted for the OTP code.
  */
 export const NoOtpCredentials: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                otpLogin: {
-                    userOtpCredentials: []
-                },
-                url: {
-                    loginAction: "/login-action"
-                },
-                messagesPerField: {
-                    existsError: () => false
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            otpLogin: {
+                userOtpCredentials: []
+            },
+            url: {
+                loginAction: "/login-action"
+            },
+            messagesPerField: {
+                existsError: () => false
+            }
+        }
+    }
 };
 
 /**
@@ -105,24 +97,22 @@ export const NoOtpCredentials: Story = {
  * - Key Aspect: Ensures that the component can handle both multiple OTP credentials and display an error message simultaneously.
  */
 export const WithErrorAndMultipleOtpCredentials: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                otpLogin: {
-                    userOtpCredentials: [
-                        { id: "credential1", userLabel: "Device 1" },
-                        { id: "credential2", userLabel: "Device 2" }
-                    ],
-                    selectedCredentialId: "credential1"
-                },
-                url: {
-                    loginAction: "/login-action"
-                },
-                messagesPerField: {
-                    existsError: (field: string) => field === "totp",
-                    get: () => "Invalid OTP code"
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            otpLogin: {
+                userOtpCredentials: [
+                    { id: "credential1", userLabel: "Device 1" },
+                    { id: "credential2", userLabel: "Device 2" }
+                ],
+                selectedCredentialId: "credential1"
+            },
+            url: {
+                loginAction: "/login-action"
+            },
+            messagesPerField: {
+                existsError: (field: string) => field === "totp",
+                get: () => "Invalid OTP code"
+            }
+        }
+    }
 };

--- a/stories/login/pages/LoginPageExpired.stories.tsx
+++ b/stories/login/pages/LoginPageExpired.stories.tsx
@@ -13,9 +13,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-    render: () => <KcPageStory />
-};
+export const Default: Story = {};
 
 /**
  * WithErrorMessage:
@@ -24,18 +22,16 @@ export const Default: Story = {
  * - Key Aspect: Ensures that error messages are displayed correctly in addition to the page expiration notice.
  */
 export const WithErrorMessage: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                url: {
-                    loginRestartFlowUrl: "/mock-restart-flow",
-                    loginAction: "/mock-continue-login"
-                },
-                message: {
-                    type: "error",
-                    summary: "An error occurred while processing your session."
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            url: {
+                loginRestartFlowUrl: "/mock-restart-flow",
+                loginAction: "/mock-continue-login"
+            },
+            message: {
+                type: "error",
+                summary: "An error occurred while processing your session."
+            }
+        }
+    }
 };

--- a/stories/login/pages/LoginPasskeysConditionalAuthenticate.stories.tsx
+++ b/stories/login/pages/LoginPasskeysConditionalAuthenticate.stories.tsx
@@ -13,6 +13,4 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-    render: () => <KcPageStory />
-};
+export const Default: Story = {};

--- a/stories/login/pages/LoginPassword.stories.tsx
+++ b/stories/login/pages/LoginPassword.stories.tsx
@@ -13,9 +13,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-    render: () => <KcPageStory />
-};
+export const Default: Story = {};
 
 /**
  * WithPasswordError:
@@ -24,23 +22,21 @@ export const Default: Story = {
  * - Key Aspect: Ensures that the password input field displays error messages correctly.
  */
 export const WithPasswordError: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                realm: {
-                    resetPasswordAllowed: true
-                },
-                url: {
-                    loginAction: "/mock-login",
-                    loginResetCredentialsUrl: "/mock-reset-password"
-                },
-                messagesPerField: {
-                    existsError: (field: string) => field === "password",
-                    get: () => "Invalid password"
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            realm: {
+                resetPasswordAllowed: true
+            },
+            url: {
+                loginAction: "/mock-login",
+                loginResetCredentialsUrl: "/mock-reset-password"
+            },
+            messagesPerField: {
+                existsError: (field: string) => field === "password",
+                get: () => "Invalid password"
+            }
+        }
+    }
 };
 
 /**
@@ -50,20 +46,18 @@ export const WithPasswordError: Story = {
  * - Key Aspect: Ensures that the component handles cases where resetting the password is not allowed.
  */
 export const WithoutResetPasswordOption: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                realm: {
-                    resetPasswordAllowed: false
-                },
-                url: {
-                    loginAction: "/mock-login",
-                    loginResetCredentialsUrl: "/mock-reset-password"
-                },
-                messagesPerField: {
-                    existsError: () => false
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            realm: {
+                resetPasswordAllowed: false
+            },
+            url: {
+                loginAction: "/mock-login",
+                loginResetCredentialsUrl: "/mock-reset-password"
+            },
+            messagesPerField: {
+                existsError: () => false
+            }
+        }
+    }
 };

--- a/stories/login/pages/LoginRecoveryAuthnCodeConfig.stories.tsx
+++ b/stories/login/pages/LoginRecoveryAuthnCodeConfig.stories.tsx
@@ -13,9 +13,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-    render: () => <KcPageStory />
-};
+export const Default: Story = {};
 
 /**
  * WithErrorDuringCodeGeneration:
@@ -24,17 +22,15 @@ export const Default: Story = {
  * - Key Aspect: Ensures that error messages are properly displayed when recovery code generation fails.
  */
 export const WithErrorDuringCodeGeneration: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                url: {
-                    loginAction: "/mock-login-action"
-                },
-                message: {
-                    summary: "An error occurred during recovery code generation. Please try again.",
-                    type: "error"
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            url: {
+                loginAction: "/mock-login-action"
+            },
+            message: {
+                summary: "An error occurred during recovery code generation. Please try again.",
+                type: "error"
+            }
+        }
+    }
 };

--- a/stories/login/pages/LoginRecoveryAuthnCodeInput.stories.tsx
+++ b/stories/login/pages/LoginRecoveryAuthnCodeInput.stories.tsx
@@ -13,6 +13,4 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-    render: () => <KcPageStory />
-};
+export const Default: Story = {};

--- a/stories/login/pages/LoginResetOtp.stories.tsx
+++ b/stories/login/pages/LoginResetOtp.stories.tsx
@@ -13,9 +13,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-    render: () => <KcPageStory />
-};
+export const Default: Story = {};
 
 /**
  * WithoutOtpCredentials:
@@ -24,22 +22,20 @@ export const Default: Story = {
  * - Key Aspect: Ensures that the component handles the absence of OTP credentials correctly.
  */
 export const WithoutOtpCredentials: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                url: {
-                    loginAction: "/mock-login"
-                },
-                configuredOtpCredentials: {
-                    userOtpCredentials: [],
-                    selectedCredentialId: undefined
-                },
-                messagesPerField: {
-                    existsError: () => false
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            url: {
+                loginAction: "/mock-login"
+            },
+            configuredOtpCredentials: {
+                userOtpCredentials: [],
+                selectedCredentialId: undefined
+            },
+            messagesPerField: {
+                existsError: () => false
+            }
+        }
+    }
 };
 
 /**
@@ -49,26 +45,24 @@ export const WithoutOtpCredentials: Story = {
  * - Key Aspect: Ensures that error messages are displayed correctly for OTP-related errors.
  */
 export const WithOtpError: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                url: {
-                    loginAction: "/mock-login"
-                },
-                configuredOtpCredentials: {
-                    userOtpCredentials: [
-                        { id: "otp1", userLabel: "Device 1" },
-                        { id: "otp2", userLabel: "Device 2" }
-                    ],
-                    selectedCredentialId: "otp1"
-                },
-                messagesPerField: {
-                    existsError: (field: string) => field === "totp",
-                    get: () => "Invalid OTP selection"
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            url: {
+                loginAction: "/mock-login"
+            },
+            configuredOtpCredentials: {
+                userOtpCredentials: [
+                    { id: "otp1", userLabel: "Device 1" },
+                    { id: "otp2", userLabel: "Device 2" }
+                ],
+                selectedCredentialId: "otp1"
+            },
+            messagesPerField: {
+                existsError: (field: string) => field === "totp",
+                get: () => "Invalid OTP selection"
+            }
+        }
+    }
 };
 
 /**
@@ -78,20 +72,18 @@ export const WithOtpError: Story = {
  * - Key Aspect: Ensures that the component renders correctly with only one OTP credential pre-selected.
  */
 export const WithOnlyOneOtpCredential: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                url: {
-                    loginAction: "/mock-login"
-                },
-                configuredOtpCredentials: {
-                    userOtpCredentials: [{ id: "otp1", userLabel: "Device 1" }],
-                    selectedCredentialId: "otp1"
-                },
-                messagesPerField: {
-                    existsError: () => false
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            url: {
+                loginAction: "/mock-login"
+            },
+            configuredOtpCredentials: {
+                userOtpCredentials: [{ id: "otp1", userLabel: "Device 1" }],
+                selectedCredentialId: "otp1"
+            },
+            messagesPerField: {
+                existsError: () => false
+            }
+        }
+    }
 };

--- a/stories/login/pages/LoginResetPassword.stories.tsx
+++ b/stories/login/pages/LoginResetPassword.stories.tsx
@@ -13,21 +13,17 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-    render: () => <KcPageStory />
-};
+export const Default: Story = {};
 
 export const WithEmailAsUsername: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                realm: {
-                    loginWithEmailAllowed: true,
-                    registrationEmailAsUsername: true
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            realm: {
+                loginWithEmailAllowed: true,
+                registrationEmailAsUsername: true
+            }
+        }
+    }
 };
 /**
  * WithUsernameError:
@@ -36,26 +32,24 @@ export const WithEmailAsUsername: Story = {
  * - Key Aspect: Ensures the username input shows error messages when validation fails.
  */
 export const WithUsernameError: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                realm: {
-                    loginWithEmailAllowed: false,
-                    registrationEmailAsUsername: false,
-                    duplicateEmailsAllowed: false
-                },
-                url: {
-                    loginAction: "/mock-login-action",
-                    loginUrl: "/mock-login-url"
-                },
-                messagesPerField: {
-                    existsError: (field: string) => field === "username",
-                    get: () => "Invalid username"
-                },
-                auth: {
-                    attemptedUsername: "invalid_user"
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            realm: {
+                loginWithEmailAllowed: false,
+                registrationEmailAsUsername: false,
+                duplicateEmailsAllowed: false
+            },
+            url: {
+                loginAction: "/mock-login-action",
+                loginUrl: "/mock-login-url"
+            },
+            messagesPerField: {
+                existsError: (field: string) => field === "username",
+                get: () => "Invalid username"
+            },
+            auth: {
+                attemptedUsername: "invalid_user"
+            }
+        }
+    }
 };

--- a/stories/login/pages/LoginUpdatePassword.stories.tsx
+++ b/stories/login/pages/LoginUpdatePassword.stories.tsx
@@ -13,9 +13,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-    render: () => <KcPageStory />
-};
+export const Default: Story = {};
 
 /**
  * WithPasswordError:
@@ -24,20 +22,18 @@ export const Default: Story = {
  * - Key Aspect: Ensures the password input field shows an error message when validation fails.
  */
 export const WithPasswordError: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                url: {
-                    loginAction: "/mock-login-action"
-                },
-                messagesPerField: {
-                    existsError: (field: string) => field === "password",
-                    get: () => "Password must be at least 8 characters long."
-                },
-                isAppInitiatedAction: false
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            url: {
+                loginAction: "/mock-login-action"
+            },
+            messagesPerField: {
+                existsError: (field: string) => field === "password",
+                get: () => "Password must be at least 8 characters long."
+            },
+            isAppInitiatedAction: false
+        }
+    }
 };
 
 /**
@@ -47,18 +43,16 @@ export const WithPasswordError: Story = {
  * - Key Aspect: Ensures that the password confirmation field shows an error when passwords do not match.
  */
 export const WithPasswordConfirmError: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                url: {
-                    loginAction: "/mock-login-action"
-                },
-                messagesPerField: {
-                    existsError: (field: string) => field === "password-confirm",
-                    get: () => "Passwords do not match."
-                },
-                isAppInitiatedAction: false
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            url: {
+                loginAction: "/mock-login-action"
+            },
+            messagesPerField: {
+                existsError: (field: string) => field === "password-confirm",
+                get: () => "Passwords do not match."
+            },
+            isAppInitiatedAction: false
+        }
+    }
 };

--- a/stories/login/pages/LoginUpdateProfile.stories.tsx
+++ b/stories/login/pages/LoginUpdateProfile.stories.tsx
@@ -13,9 +13,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-    render: () => <KcPageStory />
-};
+export const Default: Story = {};
 
 /**
  * WithProfileError:
@@ -24,18 +22,16 @@ export const Default: Story = {
  * - Key Aspect: Ensures the profile fields show error messages when validation fails.
  */
 export const WithProfileError: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                url: {
-                    loginAction: "/mock-login-action"
-                },
-                messagesPerField: {
-                    existsError: (field: string) => field === "email",
-                    get: () => "Invalid email format"
-                },
-                isAppInitiatedAction: false
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            url: {
+                loginAction: "/mock-login-action"
+            },
+            messagesPerField: {
+                existsError: (field: string) => field === "email",
+                get: () => "Invalid email format"
+            },
+            isAppInitiatedAction: false
+        }
+    }
 };

--- a/stories/login/pages/LoginUsername.stories.tsx
+++ b/stories/login/pages/LoginUsername.stories.tsx
@@ -13,19 +13,15 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-    render: () => <KcPageStory />
-};
+export const Default: Story = {};
 
 export const WithEmailAsUsername: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                realm: {
-                    loginWithEmailAllowed: true,
-                    registrationEmailAsUsername: true
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            realm: {
+                loginWithEmailAllowed: true,
+                registrationEmailAsUsername: true
+            }
+        }
+    }
 };

--- a/stories/login/pages/LoginVerifyEmail.stories.tsx
+++ b/stories/login/pages/LoginVerifyEmail.stories.tsx
@@ -14,19 +14,17 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                message: {
-                    summary: "You need to verify your email to activate your account.",
-                    type: "warning"
-                },
-                user: {
-                    email: "john.doe@gmail.com"
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            message: {
+                summary: "You need to verify your email to activate your account.",
+                type: "warning"
+            },
+            user: {
+                email: "john.doe@gmail.com"
+            }
+        }
+    }
 };
 
 /**
@@ -36,22 +34,20 @@ export const Default: Story = {
  * - Key Aspect: Ensures the success message is displayed correctly when the email is successfully verified.
  */
 export const WithSuccessMessage: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                message: {
-                    summary: "Your email has been successfully verified.",
-                    type: "success"
-                },
-                user: {
-                    email: "john.doe@gmail.com"
-                },
-                url: {
-                    loginAction: "/mock-login-action"
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            message: {
+                summary: "Your email has been successfully verified.",
+                type: "success"
+            },
+            user: {
+                email: "john.doe@gmail.com"
+            },
+            url: {
+                loginAction: "/mock-login-action"
+            }
+        }
+    }
 };
 
 /**
@@ -61,22 +57,20 @@ export const WithSuccessMessage: Story = {
  * - Key Aspect: Ensures the error message is shown correctly when the verification process encounters an issue.
  */
 export const WithErrorMessage: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                message: {
-                    summary: "There was an error verifying your email. Please try again.",
-                    type: "error"
-                },
-                user: {
-                    email: "john.doe@gmail.com"
-                },
-                url: {
-                    loginAction: "/mock-login-action"
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            message: {
+                summary: "There was an error verifying your email. Please try again.",
+                type: "error"
+            },
+            user: {
+                email: "john.doe@gmail.com"
+            },
+            url: {
+                loginAction: "/mock-login-action"
+            }
+        }
+    }
 };
 
 /**
@@ -86,20 +80,18 @@ export const WithErrorMessage: Story = {
  * - Key Aspect: Ensures the informational message is displayed properly.
  */
 export const WithInfoMessage: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                message: {
-                    summary: "Please verify your email to continue using our services.",
-                    type: "info"
-                },
-                user: {
-                    email: "john.doe@gmail.com"
-                },
-                url: {
-                    loginAction: "/mock-login-action"
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            message: {
+                summary: "Please verify your email to continue using our services.",
+                type: "info"
+            },
+            user: {
+                email: "john.doe@gmail.com"
+            },
+            url: {
+                loginAction: "/mock-login-action"
+            }
+        }
+    }
 };

--- a/stories/login/pages/LoginX509Info.stories.tsx
+++ b/stories/login/pages/LoginX509Info.stories.tsx
@@ -13,9 +13,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-    render: () => <KcPageStory />
-};
+export const Default: Story = {};
 
 /**
  * WithoutUserEnabled:
@@ -24,20 +22,18 @@ export const Default: Story = {
  * - Key Aspect: Ensures that the login buttons are not displayed when the user is not enabled.
  */
 export const WithoutUserEnabled: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                url: {
-                    loginAction: "/mock-login-action"
-                },
-                x509: {
-                    formData: {
-                        subjectDN: "CN=John Doe, OU=Example Org, O=Example Inc, C=US",
-                        username: "johndoe",
-                        isUserEnabled: false // User not enabled for login
-                    }
+    args: {
+        kcContext: {
+            url: {
+                loginAction: "/mock-login-action"
+            },
+            x509: {
+                formData: {
+                    subjectDN: "CN=John Doe, OU=Example Org, O=Example Inc, C=US",
+                    username: "johndoe",
+                    isUserEnabled: false // User not enabled for login
                 }
-            }}
-        />
-    )
+            }
+        }
+    }
 };

--- a/stories/login/pages/LogoutConfirm.stories.tsx
+++ b/stories/login/pages/LogoutConfirm.stories.tsx
@@ -13,9 +13,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-    render: () => <KcPageStory />
-};
+export const Default: Story = {};
 
 /**
  * WithCustomLogoutMessage:
@@ -24,24 +22,22 @@ export const Default: Story = {
  * - Key Aspect: Ensures the custom logout message is displayed correctly.
  */
 export const WithCustomLogoutMessage: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                url: {
-                    logoutConfirmAction: "/mock-logout-action"
-                },
-                client: {
-                    baseUrl: "/mock-client-url"
-                },
-                logoutConfirm: {
-                    code: "mock-session-code",
-                    skipLink: false
-                },
-                message: {
-                    summary: "Are you sure you want to log out from all sessions?",
-                    type: "warning"
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            url: {
+                logoutConfirmAction: "/mock-logout-action"
+            },
+            client: {
+                baseUrl: "/mock-client-url"
+            },
+            logoutConfirm: {
+                code: "mock-session-code",
+                skipLink: false
+            },
+            message: {
+                summary: "Are you sure you want to log out from all sessions?",
+                type: "warning"
+            }
+        }
+    }
 };

--- a/stories/login/pages/Register.stories.tsx
+++ b/stories/login/pages/Register.stories.tsx
@@ -14,206 +14,186 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-    render: () => <KcPageStory />
-};
+export const Default: Story = {};
 
 export const WithEmailAlreadyExists: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                profile: {
-                    attributesByName: {
-                        username: {
-                            value: "johndoe"
-                        },
-                        email: {
-                            value: "jhon.doe@gmail.com"
-                        },
-                        firstName: {
-                            value: "John"
-                        },
-                        lastName: {
-                            value: "Doe"
-                        }
+    args: {
+        kcContext: {
+            profile: {
+                attributesByName: {
+                    username: {
+                        value: "johndoe"
+                    },
+                    email: {
+                        value: "jhon.doe@gmail.com"
+                    },
+                    firstName: {
+                        value: "John"
+                    },
+                    lastName: {
+                        value: "Doe"
                     }
-                },
-                messagesPerField: {
-                    // NOTE: The other functions of messagesPerField are derived from get() and
-                    // existsError() so they are the only ones that need to mock.
-                    existsError: (fieldName: string, ...otherFieldNames: string[]) => [fieldName, ...otherFieldNames].includes("email"),
-                    get: (fieldName: string) => (fieldName === "email" ? "Email already exists." : undefined)
                 }
-            }}
-        />
-    )
+            },
+            messagesPerField: {
+                // NOTE: The other functions of messagesPerField are derived from get() and
+                // existsError() so they are the only ones that need to mock.
+                existsError: (fieldName: string, ...otherFieldNames: string[]) => [fieldName, ...otherFieldNames].includes("email"),
+                get: (fieldName: string) => (fieldName === "email" ? "Email already exists." : undefined)
+            }
+        }
+    }
 };
 
 export const WithRestrictedToMITStudents: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                profile: {
-                    attributesByName: {
-                        email: {
-                            validators: {
-                                pattern: {
-                                    pattern: "^[^@]+@([^.]+\\.)*((mit\\.edu)|(berkeley\\.edu))$",
-                                    "error-message": "${profile.attributes.email.pattern.error}"
-                                }
-                            },
-                            annotations: {
-                                inputHelperTextBefore: "${profile.attributes.email.inputHelperTextBefore}"
+    args: {
+        kcContext: {
+            profile: {
+                attributesByName: {
+                    email: {
+                        validators: {
+                            pattern: {
+                                pattern: "^[^@]+@([^.]+\\.)*((mit\\.edu)|(berkeley\\.edu))$",
+                                "error-message": "${profile.attributes.email.pattern.error}"
                             }
+                        },
+                        annotations: {
+                            inputHelperTextBefore: "${profile.attributes.email.inputHelperTextBefore}"
                         }
                     }
-                },
-                "x-keycloakify": {
-                    messages: {
-                        "profile.attributes.email.inputHelperTextBefore": "Please use your MIT or Berkeley email.",
-                        "profile.attributes.email.pattern.error":
-                            "This is not an MIT (<strong>@mit.edu</strong>) nor a Berkeley (<strong>@berkeley.edu</strong>) email."
-                    }
                 }
-            }}
-        />
-    )
+            },
+            "x-keycloakify": {
+                messages: {
+                    "profile.attributes.email.inputHelperTextBefore": "Please use your MIT or Berkeley email.",
+                    "profile.attributes.email.pattern.error":
+                        "This is not an MIT (<strong>@mit.edu</strong>) nor a Berkeley (<strong>@berkeley.edu</strong>) email."
+                }
+            }
+        }
+    }
 };
 
 export const WithFavoritePet: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                profile: {
-                    attributesByName: {
-                        favoritePet: {
-                            name: "favorite-pet",
-                            displayName: "${profile.attributes.favoritePet}",
-                            validators: {
-                                options: {
-                                    options: ["cat", "dog", "fish"]
-                                }
-                            },
-                            annotations: {
-                                inputOptionLabelsI18nPrefix: "profile.attributes.favoritePet.options"
-                            },
-                            required: false,
-                            readOnly: false
-                        } satisfies Attribute
-                    }
-                },
-                "x-keycloakify": {
-                    messages: {
-                        "profile.attributes.favoritePet": "Favorite Pet",
-                        "profile.attributes.favoritePet.options.cat": "Fluffy Cat",
-                        "profile.attributes.favoritePet.options.dog": "Loyal Dog",
-                        "profile.attributes.favoritePet.options.fish": "Peaceful Fish"
-                    }
+    args: {
+        kcContext: {
+            profile: {
+                attributesByName: {
+                    favoritePet: {
+                        name: "favorite-pet",
+                        displayName: "${profile.attributes.favoritePet}",
+                        validators: {
+                            options: {
+                                options: ["cat", "dog", "fish"]
+                            }
+                        },
+                        annotations: {
+                            inputOptionLabelsI18nPrefix: "profile.attributes.favoritePet.options"
+                        },
+                        required: false,
+                        readOnly: false
+                    } satisfies Attribute
                 }
-            }}
-        />
-    )
+            },
+            "x-keycloakify": {
+                messages: {
+                    "profile.attributes.favoritePet": "Favorite Pet",
+                    "profile.attributes.favoritePet.options.cat": "Fluffy Cat",
+                    "profile.attributes.favoritePet.options.dog": "Loyal Dog",
+                    "profile.attributes.favoritePet.options.fish": "Peaceful Fish"
+                }
+            }
+        }
+    }
 };
 
 export const WithNewsletter: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                profile: {
-                    attributesByName: {
-                        newsletter: {
-                            name: "newsletter",
-                            displayName: "Sign up to the newsletter",
-                            validators: {
-                                options: {
-                                    options: ["yes"]
-                                }
+    args: {
+        kcContext: {
+            profile: {
+                attributesByName: {
+                    newsletter: {
+                        name: "newsletter",
+                        displayName: "Sign up to the newsletter",
+                        validators: {
+                            options: {
+                                options: ["yes"]
+                            }
+                        },
+                        annotations: {
+                            inputOptionLabels: {
+                                yes: "I want my email inbox filled with spam"
                             },
-                            annotations: {
-                                inputOptionLabels: {
-                                    yes: "I want my email inbox filled with spam"
-                                },
-                                inputType: "multiselect-checkboxes"
-                            },
-                            required: false,
-                            readOnly: false
-                        } satisfies Attribute
-                    }
+                            inputType: "multiselect-checkboxes"
+                        },
+                        required: false,
+                        readOnly: false
+                    } satisfies Attribute
                 }
-            }}
-        />
-    )
+            }
+        }
+    }
 };
 
 export const WithEmailAsUsername: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                realm: {
-                    registrationEmailAsUsername: true
-                },
-                profile: {
-                    attributesByName: {
-                        username: undefined
-                    }
+    args: {
+        kcContext: {
+            realm: {
+                registrationEmailAsUsername: true
+            },
+            profile: {
+                attributesByName: {
+                    username: undefined
                 }
-            }}
-        />
-    )
+            }
+        }
+    }
 };
 
 export const WithRecaptcha: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                scripts: ["https://www.google.com/recaptcha/api.js?hl=en"],
-                recaptchaRequired: true,
-                recaptchaSiteKey: "6LfQHvApAAAAAE73SYTd5vS0lB1Xr7zdiQ-6iBVa"
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            scripts: ["https://www.google.com/recaptcha/api.js?hl=en"],
+            recaptchaRequired: true,
+            recaptchaSiteKey: "6LfQHvApAAAAAE73SYTd5vS0lB1Xr7zdiQ-6iBVa"
+        }
+    }
 };
 
 export const WithRecaptchaFrench: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                locale: {
-                    currentLanguageTag: "fr"
-                },
-                scripts: ["https://www.google.com/recaptcha/api.js?hl=fr"],
-                recaptchaRequired: true,
-                recaptchaSiteKey: "6LfQHvApAAAAAE73SYTd5vS0lB1Xr7zdiQ-6iBVa"
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            locale: {
+                currentLanguageTag: "fr"
+            },
+            scripts: ["https://www.google.com/recaptcha/api.js?hl=fr"],
+            recaptchaRequired: true,
+            recaptchaSiteKey: "6LfQHvApAAAAAE73SYTd5vS0lB1Xr7zdiQ-6iBVa"
+        }
+    }
 };
 
 export const WithPasswordMinLength8: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                passwordPolicies: {
-                    length: 8
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            passwordPolicies: {
+                length: 8
+            }
+        }
+    }
 };
 
 export const WithTermsAcceptance: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                termsAcceptanceRequired: true,
-                "x-keycloakify": {
-                    messages: {
-                        termsText: "<a href='https://example.com/terms'>Service Terms of Use</a>"
-                    }
+    args: {
+        kcContext: {
+            termsAcceptanceRequired: true,
+            "x-keycloakify": {
+                messages: {
+                    termsText: "<a href='https://example.com/terms'>Service Terms of Use</a>"
                 }
-            }}
-        />
-    )
+            }
+        }
+    }
 };
 export const WithTermsNotAccepted: Story = {
     render: args => (
@@ -230,50 +210,44 @@ export const WithTermsNotAccepted: Story = {
     )
 };
 export const WithFieldErrors: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                profile: {
-                    attributesByName: {
-                        username: { value: "" },
-                        email: { value: "invalid-email" }
-                    }
-                },
-                messagesPerField: {
-                    existsError: (fieldName: string) => ["username", "email"].includes(fieldName),
-                    get: (fieldName: string) => {
-                        if (fieldName === "username") return "Username is required.";
-                        if (fieldName === "email") return "Invalid email format.";
-                    }
+    args: {
+        kcContext: {
+            profile: {
+                attributesByName: {
+                    username: { value: "" },
+                    email: { value: "invalid-email" }
                 }
-            }}
-        />
-    )
+            },
+            messagesPerField: {
+                existsError: (fieldName: string) => ["username", "email"].includes(fieldName),
+                get: (fieldName: string) => {
+                    if (fieldName === "username") return "Username is required.";
+                    if (fieldName === "email") return "Invalid email format.";
+                }
+            }
+        }
+    }
 };
 export const WithReadOnlyFields: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                profile: {
-                    attributesByName: {
-                        username: { value: "johndoe", readOnly: true },
-                        email: { value: "jhon.doe@gmail.com", readOnly: false }
-                    }
+    args: {
+        kcContext: {
+            profile: {
+                attributesByName: {
+                    username: { value: "johndoe", readOnly: true },
+                    email: { value: "jhon.doe@gmail.com", readOnly: false }
                 }
-            }}
-        />
-    )
+            }
+        }
+    }
 };
 export const WithAutoGeneratedUsername: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                profile: {
-                    attributesByName: {
-                        username: { value: "autogenerated_username" }
-                    }
+    args: {
+        kcContext: {
+            profile: {
+                attributesByName: {
+                    username: { value: "autogenerated_username" }
                 }
-            }}
-        />
-    )
+            }
+        }
+    }
 };

--- a/stories/login/pages/SamlPostForm.stories.tsx
+++ b/stories/login/pages/SamlPostForm.stories.tsx
@@ -13,6 +13,4 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-    render: () => <KcPageStory />
-};
+export const Default: Story = {};

--- a/stories/login/pages/SelectAuthenticator.stories.tsx
+++ b/stories/login/pages/SelectAuthenticator.stories.tsx
@@ -13,74 +13,68 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-    render: () => <KcPageStory />
-};
+export const Default: Story = {};
 
 export const WithDifferentAuthenticationMethods: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                auth: {
-                    authenticationSelections: [
-                        {
-                            authExecId: "25697c4e-0c80-4f2c-8eb7-2c16347e8e8d",
-                            displayName: "auth-username-password-form-display-name",
-                            helpText: "auth-username-password-form-help-text",
-                            iconCssClass: "kcAuthenticatorPasswordClass"
-                        },
-                        {
-                            authExecId: "4cb60872-ce0d-4c8f-a806-e651ed77994b",
-                            displayName: "webauthn-passwordless-display-name",
-                            helpText: "webauthn-passwordless-help-text",
-                            iconCssClass: "kcAuthenticatorWebAuthnPasswordlessClass"
-                        }
-                    ]
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            auth: {
+                authenticationSelections: [
+                    {
+                        authExecId: "25697c4e-0c80-4f2c-8eb7-2c16347e8e8d",
+                        displayName: "auth-username-password-form-display-name",
+                        helpText: "auth-username-password-form-help-text",
+                        iconCssClass: "kcAuthenticatorPasswordClass"
+                    },
+                    {
+                        authExecId: "4cb60872-ce0d-4c8f-a806-e651ed77994b",
+                        displayName: "webauthn-passwordless-display-name",
+                        helpText: "webauthn-passwordless-help-text",
+                        iconCssClass: "kcAuthenticatorWebAuthnPasswordlessClass"
+                    }
+                ]
+            }
+        }
+    }
 };
 
 export const WithRealmTranslations: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                auth: {
-                    authenticationSelections: [
-                        {
-                            authExecId: "f0c22855-eda7-4092-8565-0c22f77d2ffb",
-                            displayName: "home-idp-discovery-display-name",
-                            helpText: "home-idp-discovery-help-text",
-                            iconCssClass: "kcAuthenticatorDefaultClass"
-                        },
-                        {
-                            authExecId: "20456f5a-8b2b-45f3-98e0-551dcb27e3e1",
-                            displayName: "identity-provider-redirctor-display-name",
-                            helpText: "identity-provider-redirctor-help-text",
-                            iconCssClass: "kcAuthenticatorDefaultClass"
-                        },
-                        {
-                            authExecId: "eb435db9-474e-473a-8da7-c184fa510b96",
-                            displayName: "auth-username-password-form-display-name",
-                            helpText: "auth-username-password-help-text",
-                            iconCssClass: "kcAuthenticatorDefaultClass"
-                        }
-                    ]
-                },
-                "x-keycloakify": {
-                    messages: {
-                        "home-idp-discovery-display-name": "Home identity provider",
-                        "home-idp-discovery-help-text":
-                            "Sign in via your home identity provider which will be automatically determined based on your provided email address.",
-                        "identity-provider-redirctor-display-name": "Identity Provider Redirector",
-                        "identity-provider-redirctor-help-text": "Sign in via your identity provider.",
-                        "auth-username-password-help-text": "Sign in via your username and password."
+    args: {
+        kcContext: {
+            auth: {
+                authenticationSelections: [
+                    {
+                        authExecId: "f0c22855-eda7-4092-8565-0c22f77d2ffb",
+                        displayName: "home-idp-discovery-display-name",
+                        helpText: "home-idp-discovery-help-text",
+                        iconCssClass: "kcAuthenticatorDefaultClass"
+                    },
+                    {
+                        authExecId: "20456f5a-8b2b-45f3-98e0-551dcb27e3e1",
+                        displayName: "identity-provider-redirctor-display-name",
+                        helpText: "identity-provider-redirctor-help-text",
+                        iconCssClass: "kcAuthenticatorDefaultClass"
+                    },
+                    {
+                        authExecId: "eb435db9-474e-473a-8da7-c184fa510b96",
+                        displayName: "auth-username-password-form-display-name",
+                        helpText: "auth-username-password-help-text",
+                        iconCssClass: "kcAuthenticatorDefaultClass"
                     }
+                ]
+            },
+            "x-keycloakify": {
+                messages: {
+                    "home-idp-discovery-display-name": "Home identity provider",
+                    "home-idp-discovery-help-text":
+                        "Sign in via your home identity provider which will be automatically determined based on your provided email address.",
+                    "identity-provider-redirctor-display-name": "Identity Provider Redirector",
+                    "identity-provider-redirctor-help-text": "Sign in via your identity provider.",
+                    "auth-username-password-help-text": "Sign in via your username and password."
                 }
-            }}
-        />
-    )
+            }
+        }
+    }
 };
 
 /**
@@ -90,16 +84,14 @@ export const WithRealmTranslations: Story = {
  * - Key Aspect: Ensures that the component gracefully handles the absence of available authentication methods.
  */
 export const WithoutAuthenticationSelections: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                url: {
-                    loginAction: "/mock-login-action"
-                },
-                auth: {
-                    authenticationSelections: [] // No authentication methods available
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            url: {
+                loginAction: "/mock-login-action"
+            },
+            auth: {
+                authenticationSelections: [] // No authentication methods available
+            }
+        }
+    }
 };

--- a/stories/login/pages/Terms.stories.tsx
+++ b/stories/login/pages/Terms.stories.tsx
@@ -14,75 +14,67 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                "x-keycloakify": {
-                    messages: {
-                        termsText: "<p>My terms in <strong>English</strong></p>"
-                    }
+    args: {
+        kcContext: {
+            "x-keycloakify": {
+                messages: {
+                    termsText: "<p>My terms in <strong>English</strong></p>"
                 }
-            }}
-        />
-    )
+            }
+        }
+    }
 };
 
 export const French: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                locale: {
-                    currentLanguageTag: "fr"
-                },
-                "x-keycloakify": {
-                    // cSpell: disable
-                    messages: {
-                        termsText: "<p>Mes terme en <strong>Français</strong></p>"
-                    }
-                    // cSpell: enable
+    args: {
+        kcContext: {
+            locale: {
+                currentLanguageTag: "fr"
+            },
+            "x-keycloakify": {
+                // cSpell: disable
+                messages: {
+                    termsText: "<p>Mes terme en <strong>Français</strong></p>"
                 }
-            }}
-        />
-    )
+                // cSpell: enable
+            }
+        }
+    }
 };
 
 export const Spanish: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                locale: {
-                    currentLanguageTag: "es"
-                },
-                "x-keycloakify": {
-                    messages: {
-                        termsText: "<p>Mis términos en <strong>Español</strong></p>"
-                    }
+    args: {
+        kcContext: {
+            locale: {
+                currentLanguageTag: "es"
+            },
+            "x-keycloakify": {
+                messages: {
+                    termsText: "<p>Mis términos en <strong>Español</strong></p>"
                 }
-            }}
-        />
-    )
+            }
+        }
+    }
 };
 
 export const LongMessage: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                "x-keycloakify": {
-                    messages: {
-                        termsText: `
-                            <p>These are the terms and conditions. Please read them carefully.</p>
-                            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus lacinia odio vitae vestibulum vestibulum.</p>
-                            <p>Cras vehicula diam vel metus faucibus, at scelerisque lacus pretium. Donec ac consectetur justo. Morbi in sollicitudin nulla.</p>
-                            <p>Suspendisse potenti. Phasellus pharetra consequat ante, at dictum ligula volutpat a. Quisque ultricies velit nec nulla gravida accumsan.</p>
-                            <p>Curabitur tristique, magna id hendrerit tristique, enim nunc laoreet erat, non accumsan lacus arcu et nulla.</p>
-                            <p>Fusce feugiat nisi orci, in placerat dui luctus ut. Suspendisse in velit eu urna auctor consequat a euismod enim.</p>
-                            <p>Etiam et massa a sapien pharetra mollis. In lacinia quam id libero tincidunt, at egestas felis viverra.</p>
-                            <p>Nunc pulvinar imperdiet facilisis. Curabitur ultricies dictum lectus, nec consectetur metus fringilla id.</p>
-                            <p><strong>Please accept the terms to proceed.</strong></p>
-                        `
-                    }
+    args: {
+        kcContext: {
+            "x-keycloakify": {
+                messages: {
+                    termsText: `
+                        <p>These are the terms and conditions. Please read them carefully.</p>
+                        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus lacinia odio vitae vestibulum vestibulum.</p>
+                        <p>Cras vehicula diam vel metus faucibus, at scelerisque lacus pretium. Donec ac consectetur justo. Morbi in sollicitudin nulla.</p>
+                        <p>Suspendisse potenti. Phasellus pharetra consequat ante, at dictum ligula volutpat a. Quisque ultricies velit nec nulla gravida accumsan.</p>
+                        <p>Curabitur tristique, magna id hendrerit tristique, enim nunc laoreet erat, non accumsan lacus arcu et nulla.</p>
+                        <p>Fusce feugiat nisi orci, in placerat dui luctus ut. Suspendisse in velit eu urna auctor consequat a euismod enim.</p>
+                        <p>Etiam et massa a sapien pharetra mollis. In lacinia quam id libero tincidunt, at egestas felis viverra.</p>
+                        <p>Nunc pulvinar imperdiet facilisis. Curabitur ultricies dictum lectus, nec consectetur metus fringilla id.</p>
+                        <p><strong>Please accept the terms to proceed.</strong></p>
+                    `
                 }
-            }}
-        />
-    )
+            }
+        }
+    }
 };

--- a/stories/login/pages/UpdateEmail.stories.tsx
+++ b/stories/login/pages/UpdateEmail.stories.tsx
@@ -13,9 +13,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-    render: () => <KcPageStory />
-};
+export const Default: Story = {};
 
 /**
  * WithAppInitiatedAction:
@@ -24,17 +22,15 @@ export const Default: Story = {
  * - Key Aspect: Ensures the "Cancel" button is visible and functional during app-initiated actions.
  */
 export const WithAppInitiatedAction: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                url: {
-                    loginAction: "/mock-login-action"
-                },
-                messagesPerField: {
-                    exists: () => false
-                },
-                isAppInitiatedAction: true
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            url: {
+                loginAction: "/mock-login-action"
+            },
+            messagesPerField: {
+                exists: () => false
+            },
+            isAppInitiatedAction: true
+        }
+    }
 };

--- a/stories/login/pages/WebauthnAuthenticate.stories.tsx
+++ b/stories/login/pages/WebauthnAuthenticate.stories.tsx
@@ -13,9 +13,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-    render: () => <KcPageStory />
-};
+export const Default: Story = {};
 
 /**
  * WithMultipleAuthenticators:
@@ -24,38 +22,36 @@ export const Default: Story = {
  * - Key Aspect: Ensures that the available authenticators are displayed, and the user can select one.
  */
 export const WithMultipleAuthenticators: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                url: {
-                    loginAction: "/mock-login-action"
-                },
-                authenticators: {
-                    authenticators: [
-                        {
-                            credentialId: "authenticator-1",
-                            label: "Security Key 1",
-                            transports: {
-                                iconClass: "kcAuthenticatorUsbIcon",
-                                displayNameProperties: ["USB"]
-                            },
-                            createdAt: "2023-01-01"
+    args: {
+        kcContext: {
+            url: {
+                loginAction: "/mock-login-action"
+            },
+            authenticators: {
+                authenticators: [
+                    {
+                        credentialId: "authenticator-1",
+                        label: "Security Key 1",
+                        transports: {
+                            iconClass: "kcAuthenticatorUsbIcon",
+                            displayNameProperties: ["USB"]
                         },
-                        {
-                            credentialId: "authenticator-2",
-                            label: "Security Key 2",
-                            transports: {
-                                iconClass: "kcAuthenticatorNfcIcon",
-                                displayNameProperties: ["NFC"]
-                            },
-                            createdAt: "2023-02-01"
-                        }
-                    ]
-                },
-                shouldDisplayAuthenticators: true
-            }}
-        />
-    )
+                        createdAt: "2023-01-01"
+                    },
+                    {
+                        credentialId: "authenticator-2",
+                        label: "Security Key 2",
+                        transports: {
+                            iconClass: "kcAuthenticatorNfcIcon",
+                            displayNameProperties: ["NFC"]
+                        },
+                        createdAt: "2023-02-01"
+                    }
+                ]
+            },
+            shouldDisplayAuthenticators: true
+        }
+    }
 };
 
 /**
@@ -65,29 +61,27 @@ export const WithMultipleAuthenticators: Story = {
  * - Key Aspect: Ensures the form renders correctly when there is only one authenticator available.
  */
 export const WithSingleAuthenticator: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                url: {
-                    loginAction: "/mock-login-action"
-                },
-                authenticators: {
-                    authenticators: [
-                        {
-                            credentialId: "authenticator-1",
-                            label: "My Security Key",
-                            transports: {
-                                iconClass: "kcAuthenticatorUsbIcon",
-                                displayNameProperties: ["USB"]
-                            },
-                            createdAt: "2023-01-01"
-                        }
-                    ]
-                },
-                shouldDisplayAuthenticators: true
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            url: {
+                loginAction: "/mock-login-action"
+            },
+            authenticators: {
+                authenticators: [
+                    {
+                        credentialId: "authenticator-1",
+                        label: "My Security Key",
+                        transports: {
+                            iconClass: "kcAuthenticatorUsbIcon",
+                            displayNameProperties: ["USB"]
+                        },
+                        createdAt: "2023-01-01"
+                    }
+                ]
+            },
+            shouldDisplayAuthenticators: true
+        }
+    }
 };
 
 /**
@@ -97,33 +91,31 @@ export const WithSingleAuthenticator: Story = {
  * - Key Aspect: Ensures the form handles authentication errors and displays a relevant message.
  */
 export const WithErrorDuringAuthentication: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                url: {
-                    loginAction: "/mock-login-action"
-                },
-                authenticators: {
-                    authenticators: [
-                        {
-                            credentialId: "authenticator-1",
-                            label: "My Security Key",
-                            transports: {
-                                iconClass: "kcAuthenticatorUsbIcon",
-                                displayNameProperties: ["USB"]
-                            },
-                            createdAt: "2023-01-01"
-                        }
-                    ]
-                },
-                shouldDisplayAuthenticators: true,
-                message: {
-                    summary: "An error occurred during WebAuthn authentication.",
-                    type: "error"
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            url: {
+                loginAction: "/mock-login-action"
+            },
+            authenticators: {
+                authenticators: [
+                    {
+                        credentialId: "authenticator-1",
+                        label: "My Security Key",
+                        transports: {
+                            iconClass: "kcAuthenticatorUsbIcon",
+                            displayNameProperties: ["USB"]
+                        },
+                        createdAt: "2023-01-01"
+                    }
+                ]
+            },
+            shouldDisplayAuthenticators: true,
+            message: {
+                summary: "An error occurred during WebAuthn authentication.",
+                type: "error"
+            }
+        }
+    }
 };
 
 /**
@@ -133,27 +125,25 @@ export const WithErrorDuringAuthentication: Story = {
  * - Key Aspect: Ensures the form provides a clear message when JavaScript is required but unavailable.
  */
 export const WithJavaScriptDisabled: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                url: {
-                    loginAction: "/mock-login-action"
-                },
-                authenticators: {
-                    authenticators: [
-                        {
-                            credentialId: "authenticator-1",
-                            label: "My Security Key",
-                            transports: {
-                                iconClass: "kcAuthenticatorUsbIcon",
-                                displayNameProperties: ["USB"]
-                            },
-                            createdAt: "2023-01-01"
-                        }
-                    ]
-                },
-                shouldDisplayAuthenticators: true
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            url: {
+                loginAction: "/mock-login-action"
+            },
+            authenticators: {
+                authenticators: [
+                    {
+                        credentialId: "authenticator-1",
+                        label: "My Security Key",
+                        transports: {
+                            iconClass: "kcAuthenticatorUsbIcon",
+                            displayNameProperties: ["USB"]
+                        },
+                        createdAt: "2023-01-01"
+                    }
+                ]
+            },
+            shouldDisplayAuthenticators: true
+        }
+    }
 };

--- a/stories/login/pages/WebauthnError.stories.tsx
+++ b/stories/login/pages/WebauthnError.stories.tsx
@@ -13,9 +13,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-    render: () => <KcPageStory />
-};
+export const Default: Story = {};
 
 /**
  * WithRetryAvailable:
@@ -24,20 +22,18 @@ export const Default: Story = {
  * - Key Aspect: Ensures the retry button functionality is visible and the user can retry authentication.
  */
 export const WithRetryAvailable: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                url: {
-                    loginAction: "/mock-login-action"
-                },
-                isAppInitiatedAction: false,
-                message: {
-                    summary: "WebAuthn authentication failed. Please try again.",
-                    type: "error"
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            url: {
+                loginAction: "/mock-login-action"
+            },
+            isAppInitiatedAction: false,
+            message: {
+                summary: "WebAuthn authentication failed. Please try again.",
+                type: "error"
+            }
+        }
+    }
 };
 
 /**
@@ -47,20 +43,18 @@ export const WithRetryAvailable: Story = {
  * - Key Aspect: Ensures the form renders correctly with both "Try Again" and "Cancel" options.
  */
 export const WithAppInitiatedAction: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                url: {
-                    loginAction: "/mock-login-action"
-                },
-                isAppInitiatedAction: true,
-                message: {
-                    summary: "WebAuthn authentication failed. You can try again or cancel.",
-                    type: "error"
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            url: {
+                loginAction: "/mock-login-action"
+            },
+            isAppInitiatedAction: true,
+            message: {
+                summary: "WebAuthn authentication failed. You can try again or cancel.",
+                type: "error"
+            }
+        }
+    }
 };
 
 /**
@@ -70,18 +64,16 @@ export const WithAppInitiatedAction: Story = {
  * - Key Aspect: Ensures the retry mechanism works properly when JavaScript is disabled or unavailable.
  */
 export const WithJavaScriptDisabled: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                url: {
-                    loginAction: "/mock-login-action"
-                },
-                isAppInitiatedAction: false,
-                message: {
-                    summary: "JavaScript is disabled or not working. Please retry manually.",
-                    type: "warning"
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            url: {
+                loginAction: "/mock-login-action"
+            },
+            isAppInitiatedAction: false,
+            message: {
+                summary: "JavaScript is disabled or not working. Please retry manually.",
+                type: "warning"
+            }
+        }
+    }
 };

--- a/stories/login/pages/WebauthnRegister.stories.tsx
+++ b/stories/login/pages/WebauthnRegister.stories.tsx
@@ -13,9 +13,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-    render: () => <KcPageStory />
-};
+export const Default: Story = {};
 
 /**
  * WithRetryAvailable:
@@ -24,17 +22,15 @@ export const Default: Story = {
  * - Key Aspect: Ensures the retry functionality is available and the form allows the user to retry.
  */
 export const WithRetryAvailable: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                url: {
-                    loginAction: "/mock-login-action"
-                },
-                isSetRetry: true,
-                isAppInitiatedAction: false
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            url: {
+                loginAction: "/mock-login-action"
+            },
+            isSetRetry: true,
+            isAppInitiatedAction: false
+        }
+    }
 };
 
 /**
@@ -44,19 +40,17 @@ export const WithRetryAvailable: Story = {
  * - Key Aspect: Ensures the error message is displayed correctly, informing the user of the registration failure.
  */
 export const WithErrorDuringRegistration: Story = {
-    render: () => (
-        <KcPageStory
-            kcContext={{
-                url: {
-                    loginAction: "/mock-login-action"
-                },
-                isSetRetry: false,
-                isAppInitiatedAction: false,
-                message: {
-                    summary: "An error occurred during WebAuthn registration. Please try again.",
-                    type: "error"
-                }
-            }}
-        />
-    )
+    args: {
+        kcContext: {
+            url: {
+                loginAction: "/mock-login-action"
+            },
+            isSetRetry: false,
+            isAppInitiatedAction: false,
+            message: {
+                summary: "An error occurred during WebAuthn registration. Please try again.",
+                type: "error"
+            }
+        }
+    }
 };


### PR DESCRIPTION
This is the preferred way in Storybook and it allows us to modify kcContext passed to KcPageStory with Story decorators. This is useful, for example, to add support for globally changing the locale in kcContext via Storybook Toolbar.

https://storybook.js.org/docs/writing-stories/args

I edited the files in bulk using the following two ast-grep rules:

```yaml
id: replace-render-with-args-1
language: TSX
rule:
  all:
    - pattern:
        context: |-
          export const $_VAR = { $STORY }
        selector: object
    - pattern:
        context: "{ render: () => (<KcPageStory kcContext={ $OBJ } />) }"
        selector: object
fix: |-
  {
      args: {
          kcContext: $OBJ
      }
  }
```

```yaml
id: replace-render-with-args-2
language: TSX
rule:
  all:
    - pattern:
        context: |-
          export const $_VAR = { $STORY }
        selector: object
    - pattern:
        context: "{ render: () => <KcPageStory /> }"
        selector: object

fix: "{}"
```