### PR TITLE
support themeName prefix in properties for email themes

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,5 +121,6 @@
         "webpack-cli": "5.1.4",
         "yauzl": "^2.10.0",
         "zod": "^3.17.10"
-    }
+    },
+    "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/bin/keycloakify/generateResources/extractThemeVariantFromProperties.test.ts
+++ b/src/bin/keycloakify/generateResources/extractThemeVariantFromProperties.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { extractThemeVariantFromProperties } from "./extractThemeVariantFromProperties";
+
+describe("extractThemeVariantFromProperties", () => {
+    it("Should extract theme prefixed properties", () => {
+        const input = `
+propertyKey=Property Value 1
+property.key=Verify email
+vanilla.property.key=Verify email for Vanilla
+chocolate.property.key=Verify email for Chocolate
+        `.trim();
+
+        const actual = extractThemeVariantFromProperties(input, "vanilla", [
+            "vanilla",
+            "chocolate"
+        ]);
+
+        expect(actual).toMatchInlineSnapshot(`
+          "propertyKey=Property Value 1
+          property.key=Verify email for Vanilla"
+        `);
+    });
+});

--- a/src/bin/keycloakify/generateResources/extractThemeVariantFromProperties.ts
+++ b/src/bin/keycloakify/generateResources/extractThemeVariantFromProperties.ts
@@ -1,0 +1,21 @@
+import propertiesParser from "properties-parser";
+
+export function extractThemeVariantFromProperties(
+    propertiesContent: string,
+    themeName: string,
+    themes: string[]
+) {
+    const properties = propertiesParser.parse(propertiesContent);
+
+    const editor = Object.entries(properties).reduce((acc, [key, value]) => {
+        if (key.startsWith(themeName + ".")) {
+            acc.set(key.replace(themeName + ".", ""), value);
+        } else if (!themes.some(themeName => key.startsWith(themeName + "."))) {
+            acc.set(key, value);
+        }
+
+        return acc;
+    }, propertiesParser.createEditor());
+
+    return editor.toString();
+}

--- a/src/bin/keycloakify/generateResources/getThemeTypeDirPath.ts
+++ b/src/bin/keycloakify/generateResources/getThemeTypeDirPath.ts
@@ -1,0 +1,11 @@
+import { ThemeType } from "../../shared/constants";
+import { join } from "path";
+
+export const getThemeTypeDirPath = (params: {
+    resourcesDirPath: string;
+    themeType: ThemeType | "email";
+    themeName: string;
+}) => {
+    const { themeType, themeName, resourcesDirPath } = params;
+    return join(resourcesDirPath, "theme", themeName, themeType);
+};

--- a/src/bin/keycloakify/generateResources/mergePropertiesFiles.test.ts
+++ b/src/bin/keycloakify/generateResources/mergePropertiesFiles.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { mergePropertiesFiles } from "./mergePropertiesFiles";
+import { createFixtures } from "../../tools/testUtils";
+
+describe("mergePropertiesFiles", () => {
+    it("Should merge files in order", async () => {
+        const fixturePath = await createFixtures({
+            "a.properties": `
+propertyA=File A, Property A
+propertyB=File A, Property B
+propertyC=File A, Property C
+propertyD=File A, Property D
+`.trim(),
+            "b.properties": `
+propertyA=File B, Property A
+propertyD=File B, Property D
+propertyE=File B, Property E
+`.trim(),
+            "c.properties": `
+propertyB=File C, Property B
+propertyD=File C, Property D
+propertyF=File B, Property F
+`.trim()
+        });
+
+        const actual = mergePropertiesFiles(
+            fixturePath + "/a.properties",
+            fixturePath + "/b.properties",
+            fixturePath + "/c.properties"
+        );
+
+        expect(actual).toMatchInlineSnapshot(`
+          "propertyA=File B, Property A
+          propertyB=File C, Property B
+          propertyC=File A, Property C
+          propertyD=File C, Property D
+          propertyE=File B, Property E
+          propertyF=File B, Property F"
+        `);
+    });
+});

--- a/src/bin/keycloakify/generateResources/mergePropertiesFiles.ts
+++ b/src/bin/keycloakify/generateResources/mergePropertiesFiles.ts
@@ -1,0 +1,26 @@
+import propertiesParser from "properties-parser";
+import fs from "fs";
+
+export function mergePropertiesFiles(...files: string[]): string {
+    const messages = files.reduce(
+        (acc, filePath) => {
+            const messages = propertiesParser.parse(
+                fs.readFileSync(filePath).toString("utf8")
+            );
+
+            return {
+                ...acc,
+                ...messages
+            };
+        },
+        {} as Record<string, string>
+    );
+
+    const editor = propertiesParser.createEditor();
+
+    Object.entries(messages).forEach(([key, value]) => {
+        editor.set(key, value);
+    });
+
+    return editor.toString();
+}

--- a/src/bin/keycloakify/generateResources/steps/generateEmailResources.test.ts
+++ b/src/bin/keycloakify/generateResources/steps/generateEmailResources.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { createFixtures, readFsToListing } from "../../../tools/testUtils";
+import { generateEmailResources } from "./genereateEmailResources";
+
+describe("generateEmailResources", () => {
+    it("Should replace `xKeycloakify.themeName` in .ftl and resolve theme prefix in .properties", async () => {
+        const fixturePath = await createFixtures({
+            "email/html/email-test.ftl": `<div>\${xKeycloakify.themeName}</div>`,
+            "email/messages/messages_en.properties": `
+emailTestSubject=Default Value
+vanilla.emailTestSubject=Vanilla Value
+chocolate.emailTestSubject=Chocolate Value
+emailVerificationBody=Common Value
+`.trim()
+        });
+
+        generateEmailResources({
+            resourcesDirPath: fixturePath + "/actual",
+            themeSrcDirPath: fixturePath,
+            themeNames: ["vanilla", "chocolate"]
+        });
+
+        const actual = readFsToListing(fixturePath + "/actual");
+
+        expect(actual).toMatchInlineSnapshot(`
+          {
+            "theme/chocolate/email/html/email-test.ftl": "<div>\${"chocolate"}</div>",
+            "theme/chocolate/email/messages/messages_en.properties": "emailTestSubject=Chocolate Value
+          emailVerificationBody=Common Value",
+            "theme/vanilla/email/html/email-test.ftl": "<div>\${"vanilla"}</div>",
+            "theme/vanilla/email/messages/messages_en.properties": "emailTestSubject=Vanilla Value
+          emailVerificationBody=Common Value",
+          }
+        `);
+    });
+});

--- a/src/bin/keycloakify/generateResources/steps/genereateEmailResources.ts
+++ b/src/bin/keycloakify/generateResources/steps/genereateEmailResources.ts
@@ -1,0 +1,53 @@
+import { join as pathJoin } from "path";
+import { transformCodebase } from "../../../tools/transformCodebase";
+import { extractThemeVariantFromProperties } from "../extractThemeVariantFromProperties";
+import { getThemeTypeDirPath } from "../getThemeTypeDirPath";
+
+export function generateEmailResources(params: {
+    themeSrcDirPath: string;
+    resourcesDirPath: string;
+    themeNames: string[];
+}) {
+    const { themeSrcDirPath, resourcesDirPath, themeNames } = params;
+    const emailThemeSrcDirPath = pathJoin(themeSrcDirPath, "email");
+
+    for (const themeName of themeNames) {
+        const emailThemeDirPath = getThemeTypeDirPath({
+            resourcesDirPath,
+            themeName,
+            themeType: "email"
+        });
+
+        transformCodebase({
+            srcDirPath: emailThemeSrcDirPath,
+            destDirPath: emailThemeDirPath,
+            transformSourceCode: ({ filePath, sourceCode }) => {
+                if (filePath.endsWith(".properties")) {
+                    return {
+                        modifiedSourceCode: Buffer.from(
+                            extractThemeVariantFromProperties(
+                                sourceCode.toString("utf8"),
+                                themeName,
+                                themeNames
+                            ),
+                            "utf8"
+                        )
+                    };
+                }
+
+                if (!filePath.endsWith(".ftl")) {
+                    return { modifiedSourceCode: sourceCode };
+                }
+
+                return {
+                    modifiedSourceCode: Buffer.from(
+                        sourceCode
+                            .toString("utf8")
+                            .replace(/xKeycloakify\.themeName/g, `"${themeName}"`),
+                        "utf8"
+                    )
+                };
+            }
+        });
+    }
+}

--- a/src/bin/tools/testUtils.ts
+++ b/src/bin/tools/testUtils.ts
@@ -1,0 +1,53 @@
+import * as fs from "node:fs";
+import path from "node:path";
+import * as os from "node:os";
+
+type Listing = { [filename: string]: string };
+
+/**
+ * Create fixtures from provided listing in temp folder
+ * Alternative for mock-fs which is also mocking nodejs require calls
+ *
+ * returns a path to tmp directory with fixtures
+ */
+export async function createFixtures(listing: Listing) {
+    const tmpDir = await fs.promises.mkdtemp(
+        path.join(os.tmpdir(), `keycloackify-test-${process.pid}`)
+    );
+
+    for (const [filename, value] of Object.entries(listing)) {
+        await fs.promises.mkdir(path.join(tmpDir, path.dirname(filename)), {
+            recursive: true
+        });
+        await fs.promises.writeFile(path.join(tmpDir, filename), value);
+    }
+    return tmpDir;
+}
+
+/**
+ * Print FS to the listing, handy to use with snapshots
+ */
+export function readFsToListing(
+    directory: string,
+    filter?: (filename: string) => boolean
+): Record<string, string> {
+    const out: Record<string, string> = {};
+
+    function readDirRecursive(currentDir: string, parentPath = ""): void {
+        const entries = fs.readdirSync(currentDir);
+
+        entries.forEach(entry => {
+            const filepath = path.join(currentDir, entry);
+            const relativePath = parentPath ? `${parentPath}/${entry}` : entry;
+
+            if (fs.lstatSync(filepath).isDirectory()) {
+                readDirRecursive(filepath, relativePath);
+            } else if (!filter || filter(entry)) {
+                out[relativePath] = fs.readFileSync(filepath, "utf-8");
+            }
+        });
+    }
+
+    readDirRecursive(directory);
+    return out;
+}

--- a/src/bin/tsconfig.json
+++ b/src/bin/tsconfig.json
@@ -7,7 +7,8 @@
         "lib": ["es2015", "ES2019.Object"],
         "moduleResolution": "node",
         "outDir": "../../dist/bin",
-        "rootDir": "."
+        "rootDir": ".",
+        "skipLibCheck": true
     },
     "include": ["**/*.ts", "**/*.tsx"],
     "exclude": ["initialize-account-theme/src"]


### PR DESCRIPTION
Related https://github.com/keycloakify/keycloakify/issues/500#issuecomment-2490994180

This PR adds a way to override an email subject (and not only) for theme variant. 

Say we have two themes, **vanilla** and **chocolate**. We want to have different email subjects depending on the variant. 

```properties
emailVerificationSubject=Verify email
vanilla.emailVerificationSubject=Verify email for Vanilla
chocolate.emailVerificationSubject=Verify email for Chocolate
```

I decided to do this change because it's small, local, and non-breaking. This will already unblock me, and might be someone else to go with template theming.

Also i was quite surprised that the code mostly doesn't have any tests. I've extracted the emails part and cover it with the tests. This showcasing the approach i use extensively to test CLI in https://github.com/lingui/js-lingui

You can use this approach to test rest of the procedures in the `generateResources`. 

I find testing is very important for maintenance, it's much easier to make changes in the code and just run tests instead of linking it to the starter repo, wait for the full build and so on. 