### PR TITLE
fix checkbox markup for LoginRecoveryAuthnCodeConfig view

### DIFF
--- a/src/login/pages/LoginRecoveryAuthnCodeConfig.tsx
+++ b/src/login/pages/LoginRecoveryAuthnCodeConfig.tsx
@@ -65,17 +65,21 @@ export default function LoginRecoveryAuthnCodeConfig(props: PageProps<Extract<Kc
 
             {/* confirmation checkbox */}
             <div className={kcClsx("kcFormOptionsClass")}>
-                <input
-                    className={kcClsx("kcCheckInputClass")}
-                    type="checkbox"
-                    id="kcRecoveryCodesConfirmationCheck"
-                    name="kcRecoveryCodesConfirmationCheck"
-                    onChange={event => {
-                        //@ts-expect-error: This is inherited from the original code
-                        document.getElementById("saveRecoveryAuthnCodesBtn").disabled = !event.target.checked;
-                    }}
-                />
-                <label htmlFor="kcRecoveryCodesConfirmationCheck">{msg("recovery-codes-confirmation-message")}</label>
+                <div className="checkbox">
+                    <label>
+                        <input
+                            className={kcClsx("kcCheckInputClass")}
+                            type="checkbox"
+                            id="kcRecoveryCodesConfirmationCheck"
+                            name="kcRecoveryCodesConfirmationCheck"
+                            onChange={event => {
+                                //@ts-expect-error: This is inherited from the original code
+                                document.getElementById("saveRecoveryAuthnCodesBtn").disabled = !event.target.checked;
+                            }}
+                        />
+                        {msg("recovery-codes-confirmation-message")}
+                    </label>
+                </div>
             </div>
 
             <form action={kcContext.url.loginAction} className={kcClsx("kcFormGroupClass")} id="kc-recovery-codes-settings-form" method="post">


### PR DESCRIPTION
This is a small markup fix to align the checkbox label for the recovery codes. The HTML markup is now the same as the "sign out from other devices" checkbox.

### Screenshot

<img width="1224" alt="image" src="https://github.com/user-attachments/assets/302b29c1-c182-4857-b2ee-0c5af0aadf8c" />

> before (left) after (right)