### PR TITLE
Fix autofocus issue on Login Update Password screen

### DIFF
--- a/src/login/pages/LoginUpdatePassword.tsx
+++ b/src/login/pages/LoginUpdatePassword.tsx
@@ -73,7 +73,6 @@ export default function LoginUpdatePassword(props: PageProps<Extract<KcContext, 
                                 id="password-confirm"
                                 name="password-confirm"
                                 className={kcClsx("kcInputClass")}
-                                autoFocus
                                 autoComplete="new-password"
                                 aria-invalid={messagesPerField.existsError("password", "password-confirm")}
                             />


### PR DESCRIPTION
# Fix autofocus issue on Login Update Password screen
## Bug
On the `LoginUpdatePassword` screen, the focus is currently set on the second input field (`Confirm Password`) instead of the first one (`New Password`).  
This behavior is incorrect because the user should first enter a new password before confirming it.

## Fix
- Updated `LoginUpdatePassword.tsx` to ensure that the first input field (`New Password`) receives focus.  
- The issue was caused by both input fields having the `autofocus` attribute. According to [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autofocus), the `autofocus` attribute should only be assigned to one element per document.  
- The official Keycloak template in FTL format also applies the `autofocus` attribute only to the first input field:  
  - [Keycloak login-update-password.ftl](https://github.com/keycloak/keycloak/blob/780ec716722fadfac3c09e11a47905282f8d15b8/themes/src/main/resources/theme/base/login/login-update-password.ftl)

## Before Fix (Screenshot)
![Screenshot from 2025-01-31 01-46-19](https://github.com/user-attachments/assets/47770e31-4e3e-44ef-8f51-107efedeba8f)

## After Fix (Screenshot)
![Screenshot from 2025-01-31 02-00-05](https://github.com/user-attachments/assets/cb662d42-4f25-422f-a2a4-0e0ce03fc9d7)

This change improves the user experience by ensuring the expected input flow.  
I would appreciate it if you could review this change and consider merging it. 