### PR TITLE
feat: allow user press submit button with validation errors from useUserProfileForm hook

### DIFF
--- a/src/login/UserProfileFormFields.tsx
+++ b/src/login/UserProfileFormFields.tsx
@@ -15,13 +15,14 @@ import type { KcContext } from "./KcContext";
 import type { I18n } from "./i18n";
 
 export default function UserProfileFormFields(props: UserProfileFormFieldsProps<KcContext, I18n>) {
-    const { kcContext, i18n, kcClsx, onIsFormSubmittableValueChange, doMakeUserConfirmPassword, BeforeField, AfterField } = props;
+    const { kcContext, i18n, kcClsx, doMakeUserConfirmPassword, BeforeField, AfterField, mode, onFormData } = props;
 
     const { advancedMsg } = i18n;
 
     const {
         formState: { formFieldStates, isFormSubmittable },
-        dispatchFormAction
+        dispatchFormAction,
+        onFormSubmit
     } = useUserProfileForm({
         kcContext,
         i18n,
@@ -29,8 +30,22 @@ export default function UserProfileFormFields(props: UserProfileFormFieldsProps<
     });
 
     useEffect(() => {
-        onIsFormSubmittableValueChange(isFormSubmittable);
+        if (mode === "disabledButton") {
+            onFormData(prev => ({
+                ...prev,
+                isFormSubmittable
+            }));
+        }
     }, [isFormSubmittable]);
+
+    useEffect(() => {
+        if (mode === "activeButton") {
+            onFormData(prev => ({
+                ...prev,
+                onFormSubmit
+            }));
+        }
+    }, [onFormData]);
 
     const groupNameRef = { current: "" };
 

--- a/src/login/UserProfileFormFieldsProps.tsx
+++ b/src/login/UserProfileFormFieldsProps.tsx
@@ -2,12 +2,21 @@ import type { JSX } from "keycloakify/tools/JSX";
 import { type FormAction, type FormFieldError } from "keycloakify/login/lib/useUserProfileForm";
 import type { KcClsx } from "keycloakify/login/lib/kcClsx";
 import type { Attribute } from "keycloakify/login/KcContext";
+import { Dispatch, SetStateAction } from "react";
+import { UserProfileFormSubmit } from "./lib/getUserProfileApi";
 
 export type UserProfileFormFieldsProps<KcContext = any, I18n = any> = {
     kcContext: Extract<KcContext, { profile: unknown }>;
     i18n: I18n;
     kcClsx: KcClsx;
-    onIsFormSubmittableValueChange: (isFormSubmittable: boolean) => void;
+    mode: FormSubmitMode;
+    onFormData: Dispatch<
+        SetStateAction<{
+            mode: FormSubmitMode;
+            isFormSubmittable: boolean;
+            onFormSubmit: UserProfileFormSubmit | null;
+        }>
+    >;
     doMakeUserConfirmPassword: boolean;
     BeforeField?: (props: BeforeAfterFieldProps<I18n>) => JSX.Element | null;
     AfterField?: (props: BeforeAfterFieldProps<I18n>) => JSX.Element | null;
@@ -21,3 +30,5 @@ type BeforeAfterFieldProps<I18n> = {
     kcClsx: KcClsx;
     i18n: I18n;
 };
+
+type FormSubmitMode = "activeButton" | "disabledButton";

--- a/src/login/lib/useUserProfileForm.tsx
+++ b/src/login/lib/useUserProfileForm.tsx
@@ -116,6 +116,7 @@ export type ParamsOfUseUserProfileForm = {
 export type ReturnTypeOfUseUserProfileForm = {
     formState: FormState;
     dispatchFormAction: (action: FormAction) => void;
+    onFormSubmit: reactlessApi.UserProfileFormSubmit;
 };
 
 export function useUserProfileForm(params: ParamsOfUseUserProfileForm): ReturnTypeOfUseUserProfileForm {
@@ -161,6 +162,7 @@ export function useUserProfileForm(params: ParamsOfUseUserProfileForm): ReturnTy
 
     return {
         formState,
-        dispatchFormAction: api.dispatchFormAction
+        dispatchFormAction: api.dispatchFormAction,
+        onFormSubmit: api.onFormSubmit
     };
 }

--- a/src/login/pages/IdpReviewUserProfile.tsx
+++ b/src/login/pages/IdpReviewUserProfile.tsx
@@ -1,11 +1,12 @@
 import type { JSX } from "keycloakify/tools/JSX";
-import { useState } from "react";
+import { FormEvent, useState } from "react";
 import type { LazyOrNot } from "keycloakify/tools/LazyOrNot";
 import { getKcClsx } from "keycloakify/login/lib/kcClsx";
 import type { PageProps } from "keycloakify/login/pages/PageProps";
 import type { UserProfileFormFieldsProps } from "keycloakify/login/UserProfileFormFieldsProps";
 import type { KcContext } from "../KcContext";
 import type { I18n } from "../i18n";
+import { FormData } from "../lib/getUserProfileApi";
 
 type IdpReviewUserProfileProps = PageProps<Extract<KcContext, { pageId: "idp-review-user-profile.ftl" }>, I18n> & {
     UserProfileFormFields: LazyOrNot<(props: UserProfileFormFieldsProps) => JSX.Element>;
@@ -24,7 +25,18 @@ export default function IdpReviewUserProfile(props: IdpReviewUserProfileProps) {
 
     const { url, messagesPerField } = kcContext;
 
-    const [isFomSubmittable, setIsFomSubmittable] = useState(false);
+    const [formData, setFormData] = useState<FormData>({
+        mode: "disabledButton",
+        isFormSubmittable: false,
+        onFormSubmit: null
+    });
+
+    const handleFormSubmit = (evt: FormEvent<HTMLFormElement>) => {
+        const { onFormSubmit } = formData;
+        if (onFormSubmit) {
+            onFormSubmit(evt);
+        }
+    };
 
     return (
         <Template
@@ -36,13 +48,20 @@ export default function IdpReviewUserProfile(props: IdpReviewUserProfileProps) {
             displayRequiredFields
             headerNode={msg("loginIdpReviewProfileTitle")}
         >
-            <form id="kc-idp-review-profile-form" className={kcClsx("kcFormClass")} action={url.loginAction} method="post">
+            <form
+                id="kc-idp-review-profile-form"
+                className={kcClsx("kcFormClass")}
+                action={url.loginAction}
+                method="post"
+                onSubmit={handleFormSubmit}
+            >
                 <UserProfileFormFields
                     kcContext={kcContext}
                     i18n={i18n}
-                    onIsFormSubmittableValueChange={setIsFomSubmittable}
                     kcClsx={kcClsx}
                     doMakeUserConfirmPassword={doMakeUserConfirmPassword}
+                    onFormData={setFormData}
+                    mode={formData.mode}
                 />
                 <div className={kcClsx("kcFormGroupClass")}>
                     <div id="kc-form-options" className={kcClsx("kcFormOptionsClass")}>
@@ -53,7 +72,7 @@ export default function IdpReviewUserProfile(props: IdpReviewUserProfileProps) {
                             className={kcClsx("kcButtonClass", "kcButtonPrimaryClass", "kcButtonBlockClass", "kcButtonLargeClass")}
                             type="submit"
                             value={msgStr("doSubmit")}
-                            disabled={!isFomSubmittable}
+                            disabled={!formData?.isFormSubmittable}
                         />
                     </div>
                 </div>

--- a/src/login/pages/LoginUpdateProfile.tsx
+++ b/src/login/pages/LoginUpdateProfile.tsx
@@ -1,11 +1,12 @@
 import type { JSX } from "keycloakify/tools/JSX";
-import { useState } from "react";
+import { FormEvent, useState } from "react";
 import type { LazyOrNot } from "keycloakify/tools/LazyOrNot";
 import { getKcClsx } from "keycloakify/login/lib/kcClsx";
 import type { UserProfileFormFieldsProps } from "keycloakify/login/UserProfileFormFieldsProps";
 import type { PageProps } from "keycloakify/login/pages/PageProps";
 import type { KcContext } from "../KcContext";
 import type { I18n } from "../i18n";
+import { FormData } from "../lib/getUserProfileApi";
 
 type LoginUpdateProfileProps = PageProps<Extract<KcContext, { pageId: "login-update-profile.ftl" }>, I18n> & {
     UserProfileFormFields: LazyOrNot<(props: UserProfileFormFieldsProps) => JSX.Element>;
@@ -24,7 +25,18 @@ export default function LoginUpdateProfile(props: LoginUpdateProfileProps) {
 
     const { msg, msgStr } = i18n;
 
-    const [isFormSubmittable, setIsFormSubmittable] = useState(false);
+    const [formData, setFormData] = useState<FormData>({
+        mode: "disabledButton",
+        isFormSubmittable: false,
+        onFormSubmit: null
+    });
+
+    const handleFormSubmit = (evt: FormEvent<HTMLFormElement>) => {
+        const { onFormSubmit } = formData;
+        if (onFormSubmit) {
+            onFormSubmit(evt);
+        }
+    };
 
     return (
         <Template
@@ -36,13 +48,14 @@ export default function LoginUpdateProfile(props: LoginUpdateProfileProps) {
             headerNode={msg("loginProfileTitle")}
             displayMessage={messagesPerField.exists("global")}
         >
-            <form id="kc-update-profile-form" className={kcClsx("kcFormClass")} action={url.loginAction} method="post">
+            <form id="kc-update-profile-form" className={kcClsx("kcFormClass")} action={url.loginAction} method="post" onSubmit={handleFormSubmit}>
                 <UserProfileFormFields
                     kcContext={kcContext}
                     i18n={i18n}
                     kcClsx={kcClsx}
-                    onIsFormSubmittableValueChange={setIsFormSubmittable}
                     doMakeUserConfirmPassword={doMakeUserConfirmPassword}
+                    onFormData={setFormData}
+                    mode={formData.mode}
                 />
                 <div className={kcClsx("kcFormGroupClass")}>
                     <div id="kc-form-options" className={kcClsx("kcFormOptionsClass")}>
@@ -50,7 +63,7 @@ export default function LoginUpdateProfile(props: LoginUpdateProfileProps) {
                     </div>
                     <div id="kc-form-buttons" className={kcClsx("kcFormButtonsClass")}>
                         <input
-                            disabled={!isFormSubmittable}
+                            disabled={!formData?.isFormSubmittable}
                             className={kcClsx(
                                 "kcButtonClass",
                                 "kcButtonPrimaryClass",

--- a/src/login/pages/Register.tsx
+++ b/src/login/pages/Register.tsx
@@ -1,5 +1,5 @@
 import type { JSX } from "keycloakify/tools/JSX";
-import { useState } from "react";
+import { FormEvent, useState } from "react";
 import type { LazyOrNot } from "keycloakify/tools/LazyOrNot";
 import { kcSanitize } from "keycloakify/lib/kcSanitize";
 import { getKcClsx, type KcClsx } from "keycloakify/login/lib/kcClsx";
@@ -8,6 +8,7 @@ import type { UserProfileFormFieldsProps } from "keycloakify/login/UserProfileFo
 import type { PageProps } from "keycloakify/login/pages/PageProps";
 import type { KcContext } from "../KcContext";
 import type { I18n } from "../i18n";
+import { FormData } from "../lib/getUserProfileApi";
 
 type RegisterProps = PageProps<Extract<KcContext, { pageId: "register.ftl" }>, I18n> & {
     UserProfileFormFields: LazyOrNot<(props: UserProfileFormFieldsProps) => JSX.Element>;
@@ -27,7 +28,19 @@ export default function Register(props: RegisterProps) {
 
     const { msg, msgStr, advancedMsg } = i18n;
 
-    const [isFormSubmittable, setIsFormSubmittable] = useState(false);
+    const [formData, setFormData] = useState<FormData>({
+        mode: "disabledButton",
+        isFormSubmittable: false,
+        onFormSubmit: null
+    });
+
+    const handleFormSubmit = (evt: FormEvent<HTMLFormElement>) => {
+        const { onFormSubmit } = formData;
+        if (onFormSubmit) {
+            onFormSubmit(evt);
+        }
+    };
+
     const [areTermsAccepted, setAreTermsAccepted] = useState(false);
 
     return (
@@ -40,13 +53,14 @@ export default function Register(props: RegisterProps) {
             displayMessage={messagesPerField.exists("global")}
             displayRequiredFields
         >
-            <form id="kc-register-form" className={kcClsx("kcFormClass")} action={url.registrationAction} method="post">
+            <form id="kc-register-form" className={kcClsx("kcFormClass")} action={url.registrationAction} method="post" onSubmit={handleFormSubmit}>
                 <UserProfileFormFields
                     kcContext={kcContext}
                     i18n={i18n}
                     kcClsx={kcClsx}
-                    onIsFormSubmittableValueChange={setIsFormSubmittable}
                     doMakeUserConfirmPassword={doMakeUserConfirmPassword}
+                    onFormData={setFormData}
+                    mode={formData.mode}
                 />
                 {termsAcceptanceRequired && (
                     <TermsAcceptance
@@ -93,7 +107,7 @@ export default function Register(props: RegisterProps) {
                     ) : (
                         <div id="kc-form-buttons" className={kcClsx("kcFormButtonsClass")}>
                             <input
-                                disabled={!isFormSubmittable || (termsAcceptanceRequired && !areTermsAccepted)}
+                                disabled={!formData?.isFormSubmittable || (termsAcceptanceRequired && !areTermsAccepted)}
                                 className={kcClsx("kcButtonClass", "kcButtonPrimaryClass", "kcButtonBlockClass", "kcButtonLargeClass")}
                                 type="submit"
                                 value={msgStr("doRegister")}

--- a/src/login/pages/UpdateEmail.tsx
+++ b/src/login/pages/UpdateEmail.tsx
@@ -1,11 +1,12 @@
 import type { JSX } from "keycloakify/tools/JSX";
-import { useState } from "react";
+import { FormEvent, useState } from "react";
 import type { LazyOrNot } from "keycloakify/tools/LazyOrNot";
 import { getKcClsx, type KcClsx } from "keycloakify/login/lib/kcClsx";
 import type { UserProfileFormFieldsProps } from "keycloakify/login/UserProfileFormFieldsProps";
 import type { PageProps } from "keycloakify/login/pages/PageProps";
 import type { KcContext } from "../KcContext";
 import type { I18n } from "../i18n";
+import { FormData } from "../lib/getUserProfileApi";
 
 type UpdateEmailProps = PageProps<Extract<KcContext, { pageId: "update-email.ftl" }>, I18n> & {
     UserProfileFormFields: LazyOrNot<(props: UserProfileFormFieldsProps) => JSX.Element>;
@@ -22,7 +23,18 @@ export default function UpdateEmail(props: UpdateEmailProps) {
 
     const { msg, msgStr } = i18n;
 
-    const [isFormSubmittable, setIsFormSubmittable] = useState(false);
+    const [formData, setFormData] = useState<FormData>({
+        mode: "disabledButton",
+        isFormSubmittable: false,
+        onFormSubmit: null
+    });
+
+    const handleFormSubmit = (evt: FormEvent<HTMLFormElement>) => {
+        const { onFormSubmit } = formData;
+        if (onFormSubmit) {
+            onFormSubmit(evt);
+        }
+    };
 
     const { url, messagesPerField, isAppInitiatedAction } = kcContext;
 
@@ -36,13 +48,14 @@ export default function UpdateEmail(props: UpdateEmailProps) {
             displayRequiredFields
             headerNode={msg("updateEmailTitle")}
         >
-            <form id="kc-update-email-form" className={kcClsx("kcFormClass")} action={url.loginAction} method="post">
+            <form id="kc-update-email-form" className={kcClsx("kcFormClass")} action={url.loginAction} method="post" onSubmit={handleFormSubmit}>
                 <UserProfileFormFields
                     kcContext={kcContext}
                     i18n={i18n}
                     kcClsx={kcClsx}
-                    onIsFormSubmittableValueChange={setIsFormSubmittable}
                     doMakeUserConfirmPassword={doMakeUserConfirmPassword}
+                    onFormData={setFormData}
+                    mode={formData.mode}
                 />
 
                 <div className={kcClsx("kcFormGroupClass")}>
@@ -54,7 +67,7 @@ export default function UpdateEmail(props: UpdateEmailProps) {
 
                     <div id="kc-form-buttons" className={kcClsx("kcFormButtonsClass")}>
                         <input
-                            disabled={!isFormSubmittable}
+                            disabled={!formData?.isFormSubmittable}
                             className={kcClsx(
                                 "kcButtonClass",
                                 "kcButtonPrimaryClass",


### PR DESCRIPTION
**Enhancement: Flexible Form Validation and Submission Handling in UserProfileFormFields**
**Problem**
Currently, the only way to handle client-side validation and submit the form is through the isFormSubmittable state, which is set in UserProfileFormFields via setIsFormSubmittable. Additionally, the onIsFormSubmittableValueChange prop is mandatory.

The issue with this approach is that it fully disables the submit button when the form is invalid, preventing users from interacting with it. While this behavior may be suitable for some projects, it might not be flexible enough for others.

**Proposed Solution**
To introduce more flexibility, I suggest refactoring the form validation and submission approach by introducing formData.

**Now, instead of relying only on isFormSubmittable, we have a single state object (formData) that allows users to configure form behavior dynamically. The formData object includes:**

mode - active or disabled button
isFormSubmittable – determines whether the submit button should be disabled.
onFormSubmit – a function that handles form submission.

**Enhancements to onFormSubmit**
The onFormSubmit function now accepts:
The form event (event).
An options object as the second parameter, which includes:
shouldSubmit (default: true) – when set to false, it prevents the default form submission, allowing users to handle submission manually after validation.

Depending on the desired behavior, users can adjust formData values to either:
Block the submit button completely (default behavior).
Allow clicking the button, but prevent submission when validation fails, show errors and focus on the first field with error (new behavior).

**Additionally, the UserProfileFormFields component has been updated:**

The onIsFormSubmittableValueChange prop has been removed.
Instead, two new props have been introduced:
mode – determines the form submission behavior.
onFormData– allows managing formState externally.

This update provides greater flexibility while maintaining backward compatibility with the previous validation method.