### PR TITLE
fix: add whitespace before required actions in info page

### DIFF
--- a/src/login/pages/Info.tsx
+++ b/src/login/pages/Info.tsx
@@ -31,10 +31,10 @@ export default function Info(props: PageProps<Extract<KcContext, { pageId: "info
                     dangerouslySetInnerHTML={{
                         __html: kcSanitize(
                             (() => {
-                                let html = message.summary;
+                                let html = message.summary?.trim();
 
                                 if (requiredActions) {
-                                    html += "<b>";
+                                    html += " <b>";
 
                                     html += requiredActions.map(requiredAction => advancedMsgStr(`requiredAction.${requiredAction}`)).join(", ");
 

--- a/stories/login/pages/Info.stories.tsx
+++ b/stories/login/pages/Info.stories.tsx
@@ -46,7 +46,7 @@ export const WithRequiredActions: Story = {
             kcContext={{
                 messageHeader: "Message header",
                 message: {
-                    summary: "Required actions: "
+                    summary: "Required actions:"
                 },
                 requiredActions: ["CONFIGURE_TOTP", "UPDATE_PROFILE", "VERIFY_EMAIL", "CUSTOM_ACTION"],
                 "x-keycloakify": {


### PR DESCRIPTION
There is a whitespace missing when required actions are listed.

Before:

![Screenshot 2025-03-21 at 11-34-30 Sign in to myrealm](https://github.com/user-attachments/assets/7e2d65d6-a7cb-44f1-82c2-884174dc7f57)

After:

![Screenshot 2025-03-21 at 11-35-49 Sign in to myrealm](https://github.com/user-attachments/assets/50794d45-b31c-4a9b-8b84-3d3561386908)

This whitespace is also present in the original [keycloak theme](https://github.com/keycloak/keycloak/blob/afde8ece15aefc46f80e8efe30e1c9f81d66dd9a/themes/src/main/resources/theme/base/login/info.ftl#L11).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of summary messages to prevent potential errors when data is missing.
  
- **Style**
	- Updated text formatting for consistent spacing and punctuation in displayed messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->