### PR TITLE
Add Story for AppInitiatedAction to UpdatePassword

### DIFF
--- a/stories/login/pages/LoginUpdatePassword.stories.tsx
+++ b/stories/login/pages/LoginUpdatePassword.stories.tsx
@@ -62,3 +62,22 @@ export const WithPasswordConfirmError: Story = {
         />
     )
 };
+
+/**
+ * WithAppInitiatedAction:
+ * - Purpose: Tests when the update password action was triggered by an app.
+ * - Scenario: Simulates the case where the user presses a 'change password' button in an app and is redirected to Keycloak to change it.
+ * - Key Aspect: Ensures the 'Cancel' button is shown correctly, which displays only when the action is app initiated.
+ */
+export const WithAppInitiatedAction: Story = {
+    render: () => (
+        <KcPageStory
+            kcContext={{
+                url: {
+                    loginAction: "/mock-login-action"
+                },
+                isAppInitiatedAction: true
+            }}
+        />
+    )
+};


### PR DESCRIPTION
As mentioned in #828 

Adds a story where the action is user initiated, which shows a cancel button, so people can see if it is styled correctly, etc.

P.S: Your contributing guidelines link to https://docs.keycloakify.dev/faq-and-help/contributing , which is a dead link.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new interactive scenario in the login update password flow, simulating a user-initiated change password action that redirects to an external security process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->