### PR TITLE
use unused variable realm

### DIFF
--- a/src/login/Template.tsx
+++ b/src/login/Template.tsx
@@ -32,7 +32,7 @@ export default function Template(props: TemplateProps<KcContext, I18n>) {
     const { realm, auth, url, message, isAppInitiatedAction } = kcContext;
 
     useEffect(() => {
-        document.title = documentTitle ?? msgStr("loginTitle", kcContext.realm.displayName);
+        document.title = documentTitle ?? msgStr("loginTitle", realm.displayName);
     }, []);
 
     useSetClassName({


### PR DESCRIPTION
my vite build throws an error for variable realm in line 32 (defined but not used). Therefore, use realm.displayName instead of kcContext.realm.displayName

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified how the document title is set on the login page for improved code clarity. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->