### PR TITLE
fix: login-otp stories now correctly provide multi-otp selector id.

### DIFF
--- a/stories/login/pages/LoginOtp.stories.tsx
+++ b/stories/login/pages/LoginOtp.stories.tsx
@@ -31,10 +31,10 @@ export const MultipleOtpCredentials: Story = {
                     userOtpCredentials: [
                         { id: "credential1", userLabel: "Device 1" },
                         { id: "credential2", userLabel: "Device 2" },
-                        { id: "credential2", userLabel: "Device 3" },
-                        { id: "credential2", userLabel: "Device 4" },
-                        { id: "credential2", userLabel: "Device 5" },
-                        { id: "credential2", userLabel: "Device 6" }
+                        { id: "credential3", userLabel: "Device 3" },
+                        { id: "credential4", userLabel: "Device 4" },
+                        { id: "credential5", userLabel: "Device 5" },
+                        { id: "credential6", userLabel: "Device 6" }
                     ],
                     selectedCredentialId: "credential1"
                 },


### PR DESCRIPTION
This is a one-shot patch for Login OTP story that has invalid(?) selector for OTP credentials id.

If the duplicated ids are intended purpose or behavior, I will close the PR (though, I am unsure why no one has mentioned this.)

Btw, thank you for all the efforts, @garronej.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where multiple OTP credentials in the story shared duplicate IDs, ensuring each credential now has a unique identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->