### PR TITLE
Tokyo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "keycloakify",
-    "version": "11.8.47-rc.1",
+    "version": "11.8.47-rc.2",
     "description": "Framework to create custom Keycloak UIs",
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "keycloakify",
-    "version": "11.8.46",
+    "version": "11.8.47-rc.1",
     "description": "Framework to create custom Keycloak UIs",
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "keycloakify",
-    "version": "11.8.47-rc.2",
+    "version": "11.8.47-rc.3",
     "description": "Framework to create custom Keycloak UIs",
     "repository": {
         "type": "git",

--- a/src/bin/init/index.ts
+++ b/src/bin/init/index.ts
@@ -1,0 +1,1 @@
+export * from "./init";

--- a/src/bin/init/init.ts
+++ b/src/bin/init/init.ts
@@ -1,4 +1,5 @@
 import { setupVitePluginIfNeeded } from "./setupVitePluginIfNeeded";
+import { setupEslint } from "./setupEslint";
 import { getBuildContext } from "../shared/buildContext";
 import { maybeDelegateCommandToCustomHandler } from "../shared/customHandler_delegate";
 import { z } from "zod";
@@ -28,6 +29,8 @@ export async function command(params: { projectDirPath: string }) {
     if (hasBeenHandled) {
         return;
     }
+
+    await setupEslint({ projectDirPath });
 
     let doAddRunDevScript = false;
 
@@ -104,7 +107,7 @@ export async function command(params: { projectDirPath: string }) {
                 process.exit(-1);
             });
 
-            console.log(value);
+            console.log(`${value}\n`);
 
             return value === YES;
         })();

--- a/src/bin/init/init.ts
+++ b/src/bin/init/init.ts
@@ -299,7 +299,7 @@ export async function command(params: { projectDirPath: string }) {
             return undefined;
         }
 
-        console.log(chalk.cyan(`\nWhich theme theme type would you like to initialize?`));
+        console.log(chalk.cyan(`Which theme theme type would you like to initialize?`));
 
         const { value } = await cliSelect({
             values

--- a/src/bin/init/init.ts
+++ b/src/bin/init/init.ts
@@ -1,0 +1,347 @@
+import { setupVitePluginIfNeeded } from "./setupVitePluginIfNeeded";
+import { getBuildContext } from "../shared/buildContext";
+import { maybeDelegateCommandToCustomHandler } from "../shared/customHandler_delegate";
+import { z } from "zod";
+import { assert, type Equals, is } from "tsafe/assert";
+import { id } from "tsafe/id";
+import * as fs from "fs/promises";
+import { runPrettier, getIsPrettierAvailable } from "../tools/runPrettier";
+import cliSelect from "cli-select";
+import { THEME_TYPES } from "../shared/constants";
+import chalk from "chalk";
+import { join as pathJoin, relative as pathRelative } from "path";
+import { existsAsync } from "../tools/fs.existsAsync";
+import { KEYCLOAK_THEME } from "../shared/constants";
+
+export async function command(params: { projectDirPath: string }) {
+    const { projectDirPath } = params;
+
+    await setupVitePluginIfNeeded({ projectDirPath });
+
+    const buildContext = getBuildContext({ projectDirPath });
+
+    const { hasBeenHandled } = await maybeDelegateCommandToCustomHandler({
+        commandName: "init",
+        buildContext
+    });
+
+    if (hasBeenHandled) {
+        return;
+    }
+
+    let doAddRunDevScript = false;
+
+    setup_src: {
+        if (buildContext.bundler !== "vite") {
+            break setup_src;
+        }
+
+        const srcDirPath = pathJoin(buildContext.themeSrcDirPath, "src");
+
+        const mainTsxFilePath = pathJoin(srcDirPath, "main.tsx");
+
+        if (!(await existsAsync(mainTsxFilePath))) {
+            break setup_src;
+        }
+
+        const isAlreadySetup = await (async () => {
+            if (buildContext.themeSrcDirPath !== srcDirPath) {
+                return true;
+            }
+
+            {
+                const basenames = await fs.readdir(srcDirPath);
+
+                for (const basename of basenames) {
+                    const path = pathJoin(srcDirPath, basename);
+
+                    if (!(await fs.stat(path)).isFile()) {
+                        continue;
+                    }
+
+                    if ((await fs.readFile(path)).toString("utf8").includes("./kc.gen")) {
+                        return true;
+                    }
+                }
+            }
+
+            for (const themeType of [...THEME_TYPES, "email"]) {
+                if (!(await existsAsync(pathJoin(srcDirPath, themeType)))) {
+                    continue;
+                }
+                return true;
+            }
+
+            return false;
+        })();
+
+        if (isAlreadySetup) {
+            break setup_src;
+        }
+
+        const doSetupAsStandalone = await (async () => {
+            const relativeProjectDirPath = pathRelative(
+                process.cwd(),
+                buildContext.projectDirPath
+            );
+
+            console.log(
+                chalk.cyan(
+                    [
+                        relativeProjectDirPath === ""
+                            ? "This Vite project"
+                            : `The Vite project at ${relativeProjectDirPath}`,
+                        "is it dedicated *only* to building a Keycloak theme?"
+                    ].join(" ")
+                )
+            );
+
+            const YES = "Yes — this project is only for the Keycloak theme (recommended)";
+            const NO =
+                "No — I'm building an app and a Keycloak theme in the same project (advanced)";
+
+            const { value } = await cliSelect({ values: [YES, NO] }).catch(() => {
+                process.exit(-1);
+            });
+
+            return value === YES;
+        })();
+
+        let files: { relativeFilePath: string; fileContent: string }[];
+
+        if (doSetupAsStandalone) {
+            const viteEnvDTsFilePath = pathJoin(
+                buildContext.themeSrcDirPath,
+                "vite-env.d.ts"
+            );
+
+            const viteEnvDTsContent = await fs.readFile(viteEnvDTsFilePath);
+
+            await fs.rm(srcDirPath, { recursive: true });
+
+            await fs.mkdir(srcDirPath);
+
+            await fs.writeFile(viteEnvDTsFilePath, viteEnvDTsContent);
+
+            files = [
+                {
+                    relativeFilePath: "main.tsx",
+                    fileContent: [
+                        `if (import.meta.env.PROD) {`,
+                        `    import("./main-kc");`,
+                        `} else {`,
+                        `    import("./main-kc.dev");`,
+                        `}`
+                    ].join("\n")
+                },
+                {
+                    relativeFilePath: "main-kc.dev.tsx",
+                    fileContent: `export {};\n`
+                },
+                {
+                    relativeFilePath: "main-kc.tsx",
+                    fileContent: [
+                        `import { createRoot } from "react-dom/client";`,
+                        `import { StrictMode } from "react";`,
+                        `import { KcPage } from "./kc.gen";`,
+                        ``,
+                        `if (!window.kcContext) {`,
+                        `    throw new Error("No Keycloak context");`,
+                        `}`,
+                        ``,
+                        `createRoot(document.getElementById("root")!).render(`,
+                        `    <StrictMode>`,
+                        `        <KcPage kcContext={window.kcContext} />`,
+                        `    </StrictMode>`,
+                        `);`
+                    ].join("\n")
+                }
+            ];
+        } else {
+            doAddRunDevScript = true;
+
+            await fs.copyFile(
+                mainTsxFilePath,
+                pathJoin(buildContext.themeSrcDirPath, "main-app.tsx")
+            );
+
+            files = [
+                {
+                    relativeFilePath: "main.tsx",
+                    fileContent: [
+                        `if (window.kcContext !== undefined) {`,
+                        `    import("./keycloak-theme/main");`,
+                        `} else if (import.meta.env.VITE_KC_DEV === "true") {`,
+                        `    import("./keycloak-theme/main.dev");`,
+                        `} else {`,
+                        `    import("./main-app");`,
+                        `}`,
+                        ``
+                    ].join("\n")
+                },
+                {
+                    relativeFilePath: pathJoin(KEYCLOAK_THEME, "main.dev.tsx"),
+                    fileContent: `export {};\n`
+                },
+                {
+                    relativeFilePath: pathJoin(KEYCLOAK_THEME, "main.tsx"),
+                    fileContent: [
+                        `import { createRoot } from "react-dom/client";`,
+                        `import { StrictMode } from "react";`,
+                        `import { KcPage } from "./kc.gen";`,
+                        ``,
+                        `if (!window.kcContext) {`,
+                        `    throw new Error("No Keycloak context");`,
+                        `}`,
+                        ``,
+                        `createRoot(document.getElementById("root")!).render(`,
+                        `    <StrictMode>`,
+                        `        <KcPage kcContext={window.kcContext} />`,
+                        `    </StrictMode>`,
+                        `);`,
+                        ``
+                    ].join("\n")
+                }
+            ];
+        }
+
+        for (let { relativeFilePath, fileContent } of files) {
+            const filePath = pathJoin(srcDirPath, relativeFilePath);
+
+            run_prettier: {
+                if (!(await getIsPrettierAvailable())) {
+                    break run_prettier;
+                }
+
+                fileContent = await runPrettier({
+                    filePath: filePath,
+                    sourceCode: fileContent
+                });
+            }
+
+            await fs.writeFile(filePath, Buffer.from(fileContent, "utf8"));
+        }
+    }
+
+    add_script: {
+        const parsedPackageJson = await (async () => {
+            type ParsedPackageJson = {
+                scripts: Record<string, string>;
+            };
+
+            const zParsedPackageJson = (() => {
+                type TargetType = ParsedPackageJson;
+
+                const zTargetType = z.object({
+                    scripts: z.record(z.string(), z.string())
+                });
+
+                assert<Equals<z.infer<typeof zTargetType>, TargetType>>();
+
+                return id<z.ZodType<TargetType>>(zTargetType);
+            })();
+
+            const parsedPackageJson = JSON.parse(
+                (await fs.readFile(buildContext.packageJsonFilePath)).toString("utf8")
+            );
+
+            zParsedPackageJson.parse(parsedPackageJson);
+
+            assert(is<ParsedPackageJson>(parsedPackageJson));
+
+            return parsedPackageJson;
+        })();
+
+        const SCRIPT_NAME = "build-keycloak-theme";
+
+        if (SCRIPT_NAME in parsedPackageJson.scripts) {
+            break add_script;
+        }
+
+        parsedPackageJson.scripts[SCRIPT_NAME] = "npm run build && keycloakify build";
+        if (doAddRunDevScript) {
+            parsedPackageJson.scripts["dev-keycloak-theme"] =
+                "VITE_KC_DEV=true npm run dev";
+        }
+
+        let packageJson_content = JSON.stringify(parsedPackageJson, null, 2);
+
+        run_prettier: {
+            if (!(await getIsPrettierAvailable())) {
+                break run_prettier;
+            }
+
+            packageJson_content = await runPrettier({
+                filePath: buildContext.packageJsonFilePath,
+                sourceCode: packageJson_content
+            });
+        }
+
+        await fs.writeFile(
+            buildContext.packageJsonFilePath,
+            Buffer.from(packageJson_content, "utf8")
+        );
+    }
+
+    const themeType = await (async () => {
+        const values = ([...THEME_TYPES, "email"] as const).filter(themeType => {
+            const wrap = buildContext.implementedThemeTypes[themeType];
+
+            return !wrap.isImplemented && !wrap.isImplemented_native;
+        });
+
+        if (values.length === 0) {
+            return undefined;
+        }
+
+        console.log(chalk.cyan(`\nWhich theme theme type would you like to initialize?`));
+
+        const { value } = await cliSelect({
+            values
+        }).catch(() => {
+            process.exit(-1);
+        });
+
+        return value;
+    })();
+
+    if (themeType === undefined) {
+        console.log(
+            chalk.gray("You already have implemented a theme type of every kind, exiting")
+        );
+        process.exit(0);
+    }
+
+    switch (themeType) {
+        case "account":
+            {
+                const { command } = await import("../initialize-account-theme");
+
+                await command({ buildContext });
+            }
+            return;
+        case "admin":
+            {
+                const { command } = await import("../initialize-admin-theme");
+
+                await command({ buildContext });
+            }
+            return;
+        case "email":
+            {
+                const { command } = await import("../initialize-email-theme");
+
+                await command({ buildContext });
+            }
+            return;
+        case "login":
+            {
+                const { command } = await import("../initialize-login-theme");
+
+                await command({ buildContext });
+            }
+            return;
+    }
+
+    assert<Equals<typeof themeType, never>>;
+}

--- a/src/bin/init/init.ts
+++ b/src/bin/init/init.ts
@@ -129,7 +129,7 @@ export async function command(params: { projectDirPath: string }) {
                 {
                     relativeFilePath: "main.tsx",
                     fileContent: [
-                        `if (import.meta.env.PROD) {`,
+                        `if (window.kcContext !== undefined) {`,
                         `    import("./main-kc");`,
                         `} else {`,
                         `    import("./main-kc.dev");`,

--- a/src/bin/init/init.ts
+++ b/src/bin/init/init.ts
@@ -36,7 +36,7 @@ export async function command(params: { projectDirPath: string }) {
             break setup_src;
         }
 
-        const srcDirPath = pathJoin(buildContext.themeSrcDirPath, "src");
+        const srcDirPath = pathJoin(buildContext.projectDirPath, "src");
 
         const mainTsxFilePath = pathJoin(srcDirPath, "main.tsx");
 

--- a/src/bin/init/init.ts
+++ b/src/bin/init/init.ts
@@ -98,11 +98,13 @@ export async function command(params: { projectDirPath: string }) {
 
             const YES = "Yes — this project is only for the Keycloak theme (recommended)";
             const NO =
-                "No — I'm building an app and a Keycloak theme in the same project (advanced)";
+                "No  — I'm building an app and a Keycloak theme in the same project (advanced)";
 
             const { value } = await cliSelect({ values: [YES, NO] }).catch(() => {
                 process.exit(-1);
             });
+
+            console.log(value);
 
             return value === YES;
         })();
@@ -301,6 +303,8 @@ export async function command(params: { projectDirPath: string }) {
         }).catch(() => {
             process.exit(-1);
         });
+
+        console.log(value);
 
         return value;
     })();

--- a/src/bin/init/setupEslint.ts
+++ b/src/bin/init/setupEslint.ts
@@ -1,0 +1,80 @@
+import { join as pathJoin } from "path";
+import { existsAsync } from "../tools/fs.existsAsync";
+import * as fs from "fs/promises";
+import * as recast from "recast";
+import { runPrettier, getIsPrettierAvailable } from "../tools/runPrettier";
+import * as babelParser from "@babel/parser";
+import babelGenerate from "@babel/generator";
+import * as babelTypes from "@babel/types";
+
+/** This function will just set reportUnusedDisableDirectives to off so that we don't get warning on generated files */
+export async function setupEslint(params: { projectDirPath: string }) {
+    const { projectDirPath } = params;
+
+    const eslintConfigJsFilePath = pathJoin(projectDirPath, "eslint.config.js");
+
+    if (!(await existsAsync(eslintConfigJsFilePath))) {
+        return;
+    }
+
+    const eslintConfigJsContent = (await fs.readFile(eslintConfigJsFilePath)).toString(
+        "utf8"
+    );
+
+    if (eslintConfigJsContent.includes("reportUnusedDisableDirectives")) {
+        return;
+    }
+
+    const root = recast.parse(eslintConfigJsContent, {
+        parser: {
+            parse: (code: string) =>
+                babelParser.parse(code, {
+                    sourceType: "module",
+                    plugins: ["typescript"]
+                })
+        }
+    });
+
+    recast.visit(root, {
+        visitExportDefaultDeclaration(path) {
+            // @ts-expect-error
+            const args = path.node.declaration.arguments;
+
+            if (!Array.isArray(args)) return false;
+
+            args.push(
+                babelTypes.objectExpression([
+                    babelTypes.objectProperty(
+                        babelTypes.identifier("linterOptions"),
+                        babelTypes.objectExpression([
+                            babelTypes.objectProperty(
+                                babelTypes.identifier("reportUnusedDisableDirectives"),
+                                babelTypes.stringLiteral("off")
+                            )
+                        ])
+                    )
+                ])
+            );
+
+            return false;
+        }
+    });
+
+    let eslintConfigJsContent_modified = babelGenerate(root).code;
+
+    format: {
+        if (!(await getIsPrettierAvailable())) {
+            break format;
+        }
+
+        eslintConfigJsContent_modified = await runPrettier({
+            sourceCode: eslintConfigJsContent_modified,
+            filePath: eslintConfigJsFilePath
+        });
+    }
+
+    await fs.writeFile(
+        eslintConfigJsFilePath,
+        Buffer.from(eslintConfigJsContent_modified, "utf8")
+    );
+}

--- a/src/bin/init/setupVitePluginIfNeeded.ts
+++ b/src/bin/init/setupVitePluginIfNeeded.ts
@@ -12,24 +12,22 @@ export async function setupVitePluginIfNeeded(params: { projectDirPath: string }
     const { projectDirPath } = params;
 
     const viteConfigTsFilePath = pathJoin(projectDirPath, "vite.config.ts");
-    const packageJsonFilePath = pathJoin(projectDirPath, "package.json");
 
-    if (
-        !(await existsAsync(viteConfigTsFilePath)) ||
-        !(await existsAsync(packageJsonFilePath))
-    ) {
+    if (!(await existsAsync(viteConfigTsFilePath))) {
         return;
     }
 
-    const viteConfigTsContent = (await fs.readFile(viteConfigTsFilePath)).toString(
-        "utf8"
-    );
+    {
+        const viteConfigTsContent = (await fs.readFile(viteConfigTsFilePath)).toString(
+            "utf8"
+        );
 
-    if (viteConfigTsContent.includes("keycloakify")) {
-        return;
+        if (viteConfigTsContent.includes("keycloakify")) {
+            return;
+        }
     }
 
-    const root = recast.parse(viteConfigTsContent, {
+    const root = recast.parse(viteConfigTsFilePath, {
         parser: {
             parse: (code: string) =>
                 babelParser.parse(code, {
@@ -66,8 +64,6 @@ export default defineConfig({
     ]
 });
         */
-
-    recast.visit(root /*...*/);
 
     recast.visit(root, {
         visitProgram(path) {
@@ -138,12 +134,12 @@ export default defineConfig({
 
         viteConfigTsContent_modified = await runPrettier({
             sourceCode: viteConfigTsContent_modified,
-            filePath: packageJsonFilePath
+            filePath: viteConfigTsFilePath
         });
     }
 
     await fs.writeFile(
-        viteConfigTsContent,
+        viteConfigTsFilePath,
         Buffer.from(viteConfigTsContent_modified, "utf8")
     );
 }

--- a/src/bin/init/setupVitePluginIfNeeded.ts
+++ b/src/bin/init/setupVitePluginIfNeeded.ts
@@ -1,0 +1,149 @@
+import { join as pathJoin } from "path";
+import { existsAsync } from "../tools/fs.existsAsync";
+import * as fs from "fs/promises";
+import * as recast from "recast";
+import { runPrettier, getIsPrettierAvailable } from "../tools/runPrettier";
+import * as babelParser from "@babel/parser";
+import babelGenerate from "@babel/generator";
+import * as babelTypes from "@babel/types";
+
+/** Best effort to setup the Keycloakify vite plugin automatically */
+export async function setupVitePluginIfNeeded(params: { projectDirPath: string }) {
+    const { projectDirPath } = params;
+
+    const viteConfigTsFilePath = pathJoin(projectDirPath, "vite.config.ts");
+    const packageJsonFilePath = pathJoin(projectDirPath, "package.json");
+
+    if (
+        !(await existsAsync(viteConfigTsFilePath)) ||
+        !(await existsAsync(packageJsonFilePath))
+    ) {
+        return;
+    }
+
+    const viteConfigTsContent = (await fs.readFile(viteConfigTsFilePath)).toString(
+        "utf8"
+    );
+
+    if (viteConfigTsContent.includes("keycloakify")) {
+        return;
+    }
+
+    const root = recast.parse(viteConfigTsContent, {
+        parser: {
+            parse: (code: string) =>
+                babelParser.parse(code, {
+                    sourceType: "module",
+                    plugins: ["typescript"]
+                }),
+            generator: babelGenerate,
+            types: babelTypes
+        }
+    });
+
+    /* Before: 
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+// https://vitejs.dev/config/
+export default defineConfig({
+    plugins: [ react() ]
+});
+        */
+
+    /* After: 
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import { keycloakify } from "keycloakify/vite-plugin";
+
+// https://vitejs.dev/config/
+export default defineConfig({
+    plugins: [
+        react(),
+        keycloakify({
+            accountThemeImplementation: "none"
+        })
+    ]
+});
+        */
+
+    recast.visit(root /*...*/);
+
+    recast.visit(root, {
+        visitProgram(path) {
+            const body = path.node.body;
+
+            // Add import: import { keycloakify } from "keycloakify/vite-plugin";
+            const importDeclaration = babelTypes.importDeclaration(
+                [
+                    babelTypes.importSpecifier(
+                        babelTypes.identifier("keycloakify"),
+                        babelTypes.identifier("keycloakify")
+                    )
+                ],
+                babelTypes.stringLiteral("keycloakify/vite-plugin")
+            );
+            // @ts-expect-error
+            body.unshift(importDeclaration);
+
+            this.traverse(path);
+        },
+        visitCallExpression(path) {
+            const { node } = path;
+
+            if (
+                // @ts-expect-error
+                babelTypes.isIdentifier(node.callee, { name: "defineConfig" }) &&
+                node.arguments.length === 1 &&
+                // @ts-expect-error
+                babelTypes.isObjectExpression(node.arguments[0])
+            ) {
+                const configObject = node.arguments[0];
+                const pluginsProp = configObject.properties.find(
+                    prop =>
+                        // @ts-expect-error
+                        babelTypes.isObjectProperty(prop) &&
+                        babelTypes.isIdentifier(prop.key, { name: "plugins" }) &&
+                        babelTypes.isArrayExpression(prop.value)
+                ) as babelTypes.ObjectProperty | undefined;
+
+                if (pluginsProp && babelTypes.isArrayExpression(pluginsProp.value)) {
+                    // Append keycloakify plugin config
+                    const keycloakifyCall = babelTypes.callExpression(
+                        babelTypes.identifier("keycloakify"),
+                        [
+                            babelTypes.objectExpression([
+                                babelTypes.objectProperty(
+                                    babelTypes.identifier("accountThemeImplementation"),
+                                    babelTypes.stringLiteral("none")
+                                )
+                            ])
+                        ]
+                    );
+
+                    pluginsProp.value.elements.push(keycloakifyCall);
+                }
+            }
+
+            this.traverse(path);
+        }
+    });
+
+    let viteConfigTsContent_modified = babelGenerate(root).code;
+
+    format: {
+        if (!(await getIsPrettierAvailable())) {
+            break format;
+        }
+
+        viteConfigTsContent_modified = await runPrettier({
+            sourceCode: viteConfigTsContent_modified,
+            filePath: packageJsonFilePath
+        });
+    }
+
+    await fs.writeFile(
+        viteConfigTsContent,
+        Buffer.from(viteConfigTsContent_modified, "utf8")
+    );
+}

--- a/src/bin/init/setupVitePluginIfNeeded.ts
+++ b/src/bin/init/setupVitePluginIfNeeded.ts
@@ -17,17 +17,15 @@ export async function setupVitePluginIfNeeded(params: { projectDirPath: string }
         return;
     }
 
-    {
-        const viteConfigTsContent = (await fs.readFile(viteConfigTsFilePath)).toString(
-            "utf8"
-        );
+    const viteConfigTsContent = (await fs.readFile(viteConfigTsFilePath)).toString(
+        "utf8"
+    );
 
-        if (viteConfigTsContent.includes("keycloakify")) {
-            return;
-        }
+    if (viteConfigTsContent.includes("keycloakify")) {
+        return;
     }
 
-    const root = recast.parse(viteConfigTsFilePath, {
+    const root = recast.parse(viteConfigTsContent, {
         parser: {
             parse: (code: string) =>
                 babelParser.parse(code, {

--- a/src/bin/initialize-account-theme/initialize-account-theme.ts
+++ b/src/bin/initialize-account-theme/initialize-account-theme.ts
@@ -26,11 +26,15 @@ export async function command(params: { buildContext: BuildContext }) {
         projectDirPath: buildContext.projectDirPath
     });
 
+    console.log(chalk.cyan("Which account theme type?"));
+
     const { value: accountThemeType } = await cliSelect({
         values: ["Single-Page" as const, "Multi-Page" as const]
     }).catch(() => {
         process.exit(-1);
     });
+
+    console.log(`${accountThemeType}\n`);
 
     switch (accountThemeType) {
         case "Multi-Page":

--- a/src/bin/initialize-login-theme.ts
+++ b/src/bin/initialize-login-theme.ts
@@ -1,0 +1,305 @@
+import { maybeDelegateCommandToCustomHandler } from "./shared/customHandler_delegate";
+import { dirname as pathDirname, join as pathJoin } from "path";
+import type { BuildContext } from "./shared/buildContext";
+import * as fs from "fs/promises";
+import { assert, is, type Equals } from "tsafe/assert";
+import { id } from "tsafe/id";
+import { addSyncExtensionsToPostinstallScript } from "./shared/addSyncExtensionsToPostinstallScript";
+import { getIsPrettierAvailable, runPrettier } from "./tools/runPrettier";
+import { npmInstall } from "./tools/npmInstall";
+import * as child_process from "child_process";
+import { z } from "zod";
+import chalk from "chalk";
+import cliSelect from "cli-select";
+import { existsAsync } from "./tools/fs.existsAsync";
+
+export async function command(params: { buildContext: BuildContext }) {
+    const { buildContext } = params;
+
+    const { hasBeenHandled } = await maybeDelegateCommandToCustomHandler({
+        commandName: "initialize-login-theme",
+        buildContext
+    });
+
+    if (hasBeenHandled) {
+        return;
+    }
+
+    if (
+        buildContext.implementedThemeTypes.login.isImplemented ||
+        buildContext.implementedThemeTypes.login.isImplemented_native
+    ) {
+        console.warn(chalk.red("There is already a login theme in your project"));
+
+        process.exit(-1);
+    }
+
+    const parsedPackageJson = await (async () => {
+        type ParsedPackageJson = {
+            scripts?: Record<string, string | undefined>;
+            dependencies?: Record<string, string | undefined>;
+            devDependencies?: Record<string, string | undefined>;
+        };
+
+        const zParsedPackageJson = (() => {
+            type TargetType = ParsedPackageJson;
+
+            const zTargetType = z.object({
+                scripts: z.record(z.union([z.string(), z.undefined()])).optional(),
+                dependencies: z.record(z.union([z.string(), z.undefined()])).optional(),
+                devDependencies: z.record(z.union([z.string(), z.undefined()])).optional()
+            });
+
+            assert<Equals<z.infer<typeof zTargetType>, TargetType>>;
+
+            return id<z.ZodType<TargetType>>(zTargetType);
+        })();
+        const parsedPackageJson = JSON.parse(
+            (await fs.readFile(buildContext.packageJsonFilePath)).toString("utf8")
+        );
+
+        zParsedPackageJson.parse(parsedPackageJson);
+
+        assert(is<ParsedPackageJson>(parsedPackageJson));
+
+        return parsedPackageJson;
+    })();
+
+    addSyncExtensionsToPostinstallScript({
+        parsedPackageJson,
+        buildContext
+    });
+
+    const doInstallStories = await (async () => {
+        console.log(chalk.cyan(`\nDo you want to install the Stories?`));
+
+        const YES = "Yes (Recommended)";
+        const NO = "No";
+
+        const { value } = await cliSelect({
+            values: [YES, NO]
+        }).catch(() => {
+            process.exit(-1);
+        });
+
+        return value === YES;
+    })();
+
+    install_storybook: {
+        if (!doInstallStories) {
+            break install_storybook;
+        }
+
+        if (buildContext.bundler !== "vite") {
+            break install_storybook;
+        }
+
+        if (
+            Object.keys({
+                ...parsedPackageJson.dependencies,
+                ...parsedPackageJson.devDependencies
+            }).includes("storybook")
+        ) {
+            break install_storybook;
+        }
+
+        (parsedPackageJson.devDependencies ??= {})["storybook"] = "^9.0.4";
+        (parsedPackageJson.devDependencies ??= {})["@storybook/react-vite"] = "^9.0.4";
+
+        const files: { relativeFilePath: string; fileContent: string }[] = [
+            {
+                relativeFilePath: "main.ts",
+                fileContent: [
+                    `import type { StorybookConfig } from "@storybook/react-vite";`,
+                    ``,
+                    `const config: StorybookConfig = {`,
+                    `    stories: ["../src/**/*.mdx", "../src/**/*.stories.@(js|jsx|mjs|ts|tsx)"],`,
+                    `    addons: [],`,
+                    `    framework: {`,
+                    `        name: "@storybook/react-vite",`,
+                    `        options: {}`,
+                    `    },`,
+                    `};`,
+                    `export default config;`,
+                    ``
+                ].join("\n")
+            },
+            {
+                relativeFilePath: "preview.ts",
+                fileContent: storybookPreviewTsFileContent
+            }
+        ];
+
+        for (let { relativeFilePath, fileContent } of files) {
+            const filePath = pathJoin(
+                buildContext.projectDirPath,
+                ".storybook",
+                relativeFilePath
+            );
+
+            {
+                const dirPath = pathDirname(filePath);
+
+                if (!(await existsAsync(dirPath))) {
+                    await fs.mkdir(dirPath, { recursive: true });
+                }
+            }
+
+            run_prettier: {
+                if (!(await getIsPrettierAvailable())) {
+                    break run_prettier;
+                }
+
+                fileContent = await runPrettier({
+                    filePath: filePath,
+                    sourceCode: fileContent
+                });
+            }
+
+            await fs.writeFile(filePath, Buffer.from(fileContent, "utf8"));
+        }
+    }
+
+    for (const moduleName of [
+        "@keycloakify/login-ui",
+        ...(!doInstallStories ? [] : ["@keycloakify/login-ui-storybook"])
+    ]) {
+        const latestVersion = await getModuleLatestVersion({ moduleName });
+
+        (parsedPackageJson.dependencies ??= {})[moduleName] = `~${latestVersion}`;
+
+        if (parsedPackageJson.devDependencies !== undefined) {
+            delete parsedPackageJson.devDependencies[moduleName];
+        }
+    }
+
+    {
+        let sourceCode = JSON.stringify(parsedPackageJson, null, 2);
+
+        if (await getIsPrettierAvailable()) {
+            sourceCode = await runPrettier({
+                sourceCode,
+                filePath: buildContext.packageJsonFilePath
+            });
+        }
+
+        await fs.writeFile(
+            buildContext.packageJsonFilePath,
+            Buffer.from(sourceCode, "utf8")
+        );
+    }
+
+    await npmInstall({
+        packageJsonDirPath: pathDirname(buildContext.packageJsonFilePath)
+    });
+}
+
+async function getModuleLatestVersion(params: { moduleName: string }) {
+    const { moduleName } = params;
+
+    const versions = ((): string[] => {
+        const cmdOutput = child_process
+            .execSync(`npm show ${moduleName} versions --json`)
+            .toString("utf8")
+            .trim();
+
+        const versions = JSON.parse(cmdOutput) as string | string[];
+
+        // NOTE: Bug in some older npm versions
+        if (typeof versions === "string") {
+            return [versions];
+        }
+
+        return versions;
+    })();
+
+    const version = versions.reverse().filter(version => !version.includes("-"))[0];
+
+    assert(version !== undefined);
+
+    return version;
+}
+
+const storybookPreviewTsFileContent = [
+    `import type { Preview } from "@storybook/react-vite";`,
+    ``,
+    `const preview: Preview = {`,
+    `    parameters: {`,
+    `        controls: {`,
+    `            matchers: {`,
+    `                color: /(background|color)$/i,`,
+    `                date: /Date$/i`,
+    `            }`,
+    `        },`,
+    `        options: {`,
+    `            storySort: (a, b)=> {`,
+    ``,
+    `                const orderedPagesPrefix = [`,
+    `                    "Introduction",`,
+    `                    "login/login.ftl",`,
+    `                    "login/register.ftl",`,
+    `                    "login/terms.ftl",`,
+    `                    "login/error.ftl",`,
+    `                    "login/code.ftl",`,
+    `                    "login/delete-account-confirm.ftl",`,
+    `                    "login/delete-credential.ftl",`,
+    `                    "login/frontchannel-logout.ftl",`,
+    `                    "login/idp-review-user-profile.ftl",`,
+    `                    "login/info.ftl",`,
+    `                    "login/login-config-totp.ftl",`,
+    `                    "login/login-idp-link-confirm.ftl",`,
+    `                    "login/login-idp-link-email.ftl",`,
+    `                    "login/login-oauth-grant.ftl",`,
+    `                    "login/login-otp.ftl",`,
+    `                    "login/login-page-expired.ftl",`,
+    `                    "login/login-password.ftl",`,
+    `                    "login/login-reset-otp.ftl",`,
+    `                    "login/login-reset-password.ftl",`,
+    `                    "login/login-update-password.ftl",`,
+    `                    "login/login-update-profile.ftl",`,
+    `                    "login/login-username.ftl",`,
+    `                    "login/login-verify-email.ftl",`,
+    `                    "login/login-x509-info.ftl",`,
+    `                    "login/logout-confirm.ftl",`,
+    `                    "login/saml-post-form.ftl",`,
+    `                    "login/select-authenticator.ftl",`,
+    `                    "login/update-email.ftl",`,
+    `                    "login/webauthn-authenticate.ftl",`,
+    `                    "login/webauthn-error.ftl",`,
+    `                    "login/webauthn-register.ftl",`,
+    `                    "login/login-oauth2-device-verify-user-code.ftl",`,
+    `                    "login/login-recovery-authn-code-config.ftl",`,
+    `                    "login/login-recovery-authn-code-input.ftl",`,
+    `                    "account/account.ftl",`,
+    `                    "account/password.ftl",`,
+    `                    "account/federatedIdentity.ftl",`,
+    `                    "account/log.ftl",`,
+    `                    "account/sessions.ftl",`,
+    `                    "account/totp.ftl"`,
+    `                ];`,
+    ``,
+    `                function getHardCodedWeight(title) {`,
+    `                    for (let i = 0; i < orderedPagesPrefix.length; i++) {`,
+    `                        if (`,
+    `                            title`,
+    `                                .toLowerCase()`,
+    `                                .startsWith(orderedPagesPrefix[i].toLowerCase())`,
+    `                        ) {`,
+    `                            return orderedPagesPrefix.length - i;`,
+    `                        }`,
+    `                    }`,
+    ``,
+    `                    return 0;`,
+    `                }`,
+    ``,
+    `                return getHardCodedWeight(b.title) - getHardCodedWeight(a.title);`,
+    ``,
+    `            }`,
+    ``,
+    `        }`,
+    `    }`,
+    `};`,
+    ``,
+    `export default preview;`,
+    ``
+].join("\n");

--- a/src/bin/initialize-login-theme.ts
+++ b/src/bin/initialize-login-theme.ts
@@ -191,6 +191,52 @@ export async function command(params: { buildContext: BuildContext }) {
         delete parsedPackageJson.dependencies[moduleName];
     }
 
+    update_main_dev: {
+        for (const fileBasename of ["main-kc.dev.tsx", "main.dev.tsx"]) {
+            const filePath = pathJoin(buildContext.themeSrcDirPath, fileBasename);
+
+            if (!(await existsAsync(filePath))) {
+                continue;
+            }
+
+            const content = (await fs.readFile(filePath)).toString("utf8");
+
+            if (!content.includes("export {}")) {
+                break update_main_dev;
+            }
+
+            let content_new = [
+                `import { createRoot } from "react-dom/client";`,
+                `import { StrictMode } from "react";`,
+                `import { KcPage } from "./kc.gen";`,
+                `import { getKcContextMock } from "./login/mocks/getKcContextMock";`,
+                ``,
+                `const kcContext = getKcContextMock({`,
+                `    pageId: "login.ftl",`,
+                `    overrides: {}`,
+                `});`,
+                ``,
+                `createRoot(document.getElementById("root")!).render(`,
+                `    <StrictMode>`,
+                `        <KcPage kcContext={kcContext} />`,
+                `    </StrictMode>`,
+                `);`,
+                ``
+            ].join("\n");
+
+            if (await getIsPrettierAvailable()) {
+                content_new = await runPrettier({
+                    sourceCode: content_new,
+                    filePath
+                });
+            }
+
+            await fs.writeFile(filePath, content_new);
+
+            break;
+        }
+    }
+
     {
         let sourceCode = JSON.stringify(parsedPackageJson, null, 2);
 

--- a/src/bin/initialize-login-theme.ts
+++ b/src/bin/initialize-login-theme.ts
@@ -168,7 +168,7 @@ export async function command(params: { buildContext: BuildContext }) {
     {
         const moduleName = "@keycloakify/login-ui";
 
-        const latestVersion = await getModuleLatestVersion({ moduleName });
+        const latestVersion = getModuleLatestVersion({ moduleName });
 
         (parsedPackageJson.dependencies ??= {})[moduleName] = `~${latestVersion}`;
 
@@ -184,7 +184,7 @@ export async function command(params: { buildContext: BuildContext }) {
 
         const moduleName = "@keycloakify/login-ui-storybook";
 
-        const latestVersion = await getModuleLatestVersion({ moduleName });
+        const latestVersion = getModuleLatestVersion({ moduleName });
 
         (parsedPackageJson.devDependencies ??= {})[moduleName] = `~${latestVersion}`;
 
@@ -212,7 +212,7 @@ export async function command(params: { buildContext: BuildContext }) {
     });
 }
 
-async function getModuleLatestVersion(params: { moduleName: string }) {
+function getModuleLatestVersion(params: { moduleName: string }) {
     const { moduleName } = params;
 
     const versions = ((): string[] => {

--- a/src/bin/initialize-login-theme.ts
+++ b/src/bin/initialize-login-theme.ts
@@ -82,7 +82,7 @@ export async function command(params: { buildContext: BuildContext }) {
             process.exit(-1);
         });
 
-        console.log(value);
+        console.log(`${value}\n`);
 
         return value === YES;
     })();

--- a/src/bin/main.ts
+++ b/src/bin/main.ts
@@ -148,6 +148,20 @@ program
 
 program
     .command({
+        name: "init",
+        description: "Initialize a new theme type (login/account/admin/email)"
+    })
+    .task({
+        skip,
+        handler: async ({ projectDirPath }) => {
+            const { command } = await import("./init");
+
+            await command({ projectDirPath: projectDirPath ?? process.cwd() });
+        }
+    });
+
+program
+    .command({
         name: "eject-page",
         description: "Eject a Keycloak page."
     })

--- a/src/bin/main.ts
+++ b/src/bin/main.ts
@@ -149,7 +149,7 @@ program
 program
     .command({
         name: "init",
-        description: "Initialize a new theme type (login/account/admin/email)"
+        description: "(BETA) Initialize a new theme type (login/account/admin/email)"
     })
     .task({
         skip,

--- a/src/bin/shared/buildContext.ts
+++ b/src/bin/shared/buildContext.ts
@@ -178,16 +178,22 @@ export function getBuildContext(params: {
             return { resolvedViteConfig: undefined };
         }
 
-        const output = child_process
-            .execSync("npx vite", {
-                cwd: projectDirPath,
-                stdio: ["pipe", "pipe", "ignore"],
-                env: {
-                    ...process.env,
-                    [VITE_PLUGIN_SUB_SCRIPTS_ENV_NAMES.RESOLVE_VITE_CONFIG]: "true"
-                }
-            })
-            .toString("utf8");
+        let output: string;
+
+        try {
+            output = child_process
+                .execSync("npx vite", {
+                    cwd: projectDirPath,
+                    stdio: ["pipe", "pipe", "ignore"],
+                    env: {
+                        ...process.env,
+                        [VITE_PLUGIN_SUB_SCRIPTS_ENV_NAMES.RESOLVE_VITE_CONFIG]: "true"
+                    }
+                })
+                .toString("utf8");
+        } catch (error) {
+            throw new Error(`Failed to run \`npx vite\`: ${error}`);
+        }
 
         assert(
             output.includes(VITE_PLUGIN_SUB_SCRIPTS_ENV_NAMES.RESOLVE_VITE_CONFIG),

--- a/src/bin/shared/buildContext.ts
+++ b/src/bin/shared/buildContext.ts
@@ -2,7 +2,6 @@ import { parse as urlParse } from "url";
 import {
     join as pathJoin,
     sep as pathSep,
-    relative as pathRelative,
     resolve as pathResolve,
     dirname as pathDirname
 } from "path";
@@ -13,8 +12,7 @@ import { assert, type Equals, is } from "tsafe/assert";
 import * as child_process from "child_process";
 import {
     VITE_PLUGIN_SUB_SCRIPTS_ENV_NAMES,
-    BUILD_FOR_KEYCLOAK_MAJOR_VERSION_ENV_NAME,
-    THEME_TYPES
+    BUILD_FOR_KEYCLOAK_MAJOR_VERSION_ENV_NAME
 } from "./constants";
 import type { KeycloakVersionRange } from "./KeycloakVersionRange";
 import { exclude } from "tsafe";
@@ -167,40 +165,7 @@ export function getBuildContext(params: {
             return { themeSrcDirPath };
         }
 
-        {
-            const basenames = fs.readdirSync(srcDirPath);
-
-            for (const basename of basenames) {
-                const path = pathJoin(srcDirPath, basename);
-
-                if (!fs.statSync(path).isFile()) {
-                    continue;
-                }
-
-                if (fs.readFileSync(path).toString("utf8").includes("./kc.gen")) {
-                    return { themeSrcDirPath: srcDirPath };
-                }
-            }
-        }
-
-        for (const themeType of [...THEME_TYPES, "email"]) {
-            if (!fs.existsSync(pathJoin(srcDirPath, themeType))) {
-                continue;
-            }
-            return { themeSrcDirPath: srcDirPath };
-        }
-
-        console.log(
-            chalk.red(
-                [
-                    `Can't locate your Keycloak theme source directory in .${pathSep}${pathRelative(process.cwd(), srcDirPath)}`,
-                    `Make sure to either use the Keycloakify CLI in the root of your Keycloakify project or use the --project CLI option`,
-                    `If you are collocating your Keycloak theme with your app you must have a directory named '${KEYCLOAK_THEME}' or '${KEYCLOAK_THEME.replace(/-/g, "_")}' in your 'src' directory`
-                ].join("\n")
-            )
-        );
-
-        process.exit(1);
+        return { themeSrcDirPath: srcDirPath };
     })();
 
     const { resolvedViteConfig } = (() => {

--- a/src/bin/shared/customHandler.ts
+++ b/src/bin/shared/customHandler.ts
@@ -10,11 +10,13 @@ export type CommandName =
     | "update-kc-gen"
     | "eject-page"
     | "add-story"
+    | "initialize-login-theme"
     | "initialize-account-theme"
     | "initialize-admin-theme"
     | "initialize-admin-theme"
     | "initialize-email-theme"
-    | "copy-keycloak-resources-to-public";
+    | "copy-keycloak-resources-to-public"
+    | "init";
 
 export type ApiVersion = "v1";
 

--- a/src/bin/tools/fetchProxyOptions.ts
+++ b/src/bin/tools/fetchProxyOptions.ts
@@ -17,10 +17,7 @@ export function getProxyFetchOptions(params: {
 
     const cfg = (() => {
         const output = child_process
-            .execSync("npm config get", {
-                cwd: npmConfigGetCwd,
-                stdio: ["pipe", "pipe", "ignore"]
-            })
+            .execSync("npm config get", { cwd: npmConfigGetCwd })
             .toString("utf8");
 
         return output

--- a/src/bin/tools/fetchProxyOptions.ts
+++ b/src/bin/tools/fetchProxyOptions.ts
@@ -18,7 +18,8 @@ export function getProxyFetchOptions(params: {
     const cfg = (() => {
         const output = child_process
             .execSync("npm config get", {
-                cwd: npmConfigGetCwd
+                cwd: npmConfigGetCwd,
+                stdio: ["pipe", "pipe", "ignore"]
             })
             .toString("utf8");
 


### PR DESCRIPTION
Minimal implementation of the next big iteration of Keycloakify to be introduced at [Keycloak Japan](https://events.linuxfoundation.org/keycloakcon-japan/)  

No breaking change.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new "init" CLI command to initialize different Keycloak theme types (login, account, admin, email).
	- Interactive setup for Keycloak theme projects, including source directory configuration and theme type selection.
	- Option to set up Storybook integration during login theme initialization.

- **Improvements**
	- Ensured consistent sorting in generated `.gitignore` files and extension metadata for more predictable outputs.
	- Enhanced ESLint and Vite plugin setup automation during project initialization.
	- Improved user prompts and console output for theme initialization commands.
	- Updated package version to 11.8.47-rc.3.
	- Deferred error output during package installation to improve clarity.
	- Disabled verbatim module syntax in project configuration to enhance compatibility.
	- Optimized fetch options handling with lazy evaluation and improved error suppression.
	- Added forced flag to npm install command for more reliable dependency installation.

- **Bug Fixes**
	- Fixed fallback detection logic for theme source directories to prevent unnecessary errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->