### PR TITLE
Fix button styles on update email and login expired forms

### DIFF
--- a/src/login/pages/LoginPageExpired.tsx
+++ b/src/login/pages/LoginPageExpired.tsx
@@ -14,7 +14,7 @@ export default function LoginPageExpired(props: PageProps<Extract<KcContext, { p
             <p id="instruction1" className="instruction">
                 {msg("pageExpiredMsg1")}
                 <a id="loginRestartLink" href={url.loginRestartFlowUrl}>
-                    {msg("doClickHere")}
+                    {msg("doClickHere")}{" "}
                 </a>{" "}
                 .<br />
                 {msg("pageExpiredMsg2")}{" "}

--- a/src/login/pages/UpdateEmail.tsx
+++ b/src/login/pages/UpdateEmail.tsx
@@ -58,7 +58,7 @@ export default function UpdateEmail(props: UpdateEmailProps) {
                             className={kcClsx(
                                 "kcButtonClass",
                                 "kcButtonPrimaryClass",
-                                isAppInitiatedAction && "kcButtonBlockClass",
+                                (!isAppInitiatedAction) && "kcButtonBlockClass",
                                 "kcButtonLargeClass"
                             )}
                             type="submit"


### PR DESCRIPTION
solves issue #877 

The submit button on the update mail form should have the class block using the whole width if it is the only button in the form and be small if the form has an additional cancel button next to ist.

I added a space at the login expired page before the link because it separates two words and gives the same style like in the line below.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved spacing consistency in the login page by adding a trailing space after a link.
  * Updated button styling on the email update page for better visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->