### PR TITLE
Fix StackOverflowError when accepting terms after IdP login

### DIFF
--- a/src/bin/keycloakify/generateFtl/kcContextDeclarationTemplate.ftl
+++ b/src/bin/keycloakify/generateFtl/kcContextDeclarationTemplate.ftl
@@ -160,7 +160,10 @@ function decodeHtmlEntities(htmlStr){
         <#local outSeq = []>
 
         <#list keys as key>
-            <#if ["class","declaredConstructors","superclass","declaringClass" ]?seq_contains(key) >
+            <#-- Exclude Java reflection-related properties that can cause issues -->
+            <#-- TypeVariableImpl properties cause IllegalAccessException with Java module system -->
+            <#if ["class","declaredConstructors","superclass","declaringClass","annotations",
+                  "genericDeclaration","annotatedBounds","declaredAnnotations","bounds","typeName" ]?seq_contains(key) >
                 <#continue>
             </#if>
 


### PR DESCRIPTION
- Add TypeVariableImpl properties to exclusion list
- Prevents IllegalAccessException from Java module system
- Fixes issue with Twitter IdP and terms required action
- Resolves recursive FreeMarker template processing

The Java module system (Java 9+) restricts access to internal reflection classes like TypeVariableImpl. When FreeMarker tries to serialize these properties, it causes IllegalAccessException which leads to infinite recursion and StackOverflowError.

This fix excludes all problematic TypeVariableImpl properties:
- genericDeclaration
- annotatedBounds
- declaredAnnotations
- bounds
- typeName
- annotations (already causing issues)

Tested with Keycloak 26.0.6 and Java 21.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Prevented stack-overflow errors on the Terms screen by excluding certain circular-reference properties, improving stability for incomplete user profiles (e.g., social IdPs).

- Documentation
  - Added comments explaining why those properties are excluded and linked to the related issue for future troubleshooting.

- Refactor
  - Expanded and centralized the exclusion list for reflection-related keys to make behavior more consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->