### PR TITLE
feat: ability to skip jar output

### DIFF
--- a/src/bin/keycloakify/keycloakify.ts
+++ b/src/bin/keycloakify/keycloakify.ts
@@ -10,10 +10,14 @@ import { readThisNpmPackageVersion } from "../tools/readThisNpmPackageVersion";
 import * as os from "os";
 import { rmSync } from "../tools/fs.rmSync";
 
-export async function command(params: { buildContext: BuildContext }) {
+export async function command(params: { buildContext: BuildContext; skipJar?: boolean }) {
     const { buildContext } = params;
 
     exit_if_maven_not_installed: {
+        if (params.skipJar) {
+            break exit_if_maven_not_installed;
+        }
+
         let commandOutput: Buffer | undefined = undefined;
 
         try {
@@ -117,12 +121,19 @@ export async function command(params: { buildContext: BuildContext }) {
         });
     }
 
-    await buildJars({
-        resourcesDirPath,
-        buildContext
-    });
-
-    rmSync(resourcesDirPath, { recursive: true });
+    if (params.skipJar) {
+        console.log(
+            chalk.yellow(
+                `⚠️  --skip-jar passed, skipping the jar building step. ${resourcesDirPath} is left intact.`
+            )
+        );
+    } else {
+        await buildJars({
+            resourcesDirPath,
+            buildContext
+        });
+        rmSync(resourcesDirPath, { recursive: true });
+    }
 
     console.log(
         chalk.green(

--- a/src/bin/main.ts
+++ b/src/bin/main.ts
@@ -64,16 +64,26 @@ function skip(_context: any, argv: { options: Record<string, unknown> }) {
 }
 
 program
-    .command({
+    .command<{ skipJar: boolean | undefined }>({
         name: "build",
         description: "Build the theme (default subcommand)."
     })
+    .option({
+        key: "skipJar",
+        name: (() => {
+            const name = "skip-jar";
+            optionsKeys.push(name);
+            return name;
+        })(),
+        description: "Skip output JAR file generation.",
+        defaultValue: false
+    })
     .task({
         skip,
-        handler: async ({ projectDirPath }) => {
+        handler: async ({ projectDirPath, skipJar }) => {
             const { command } = await import("./keycloakify");
 
-            await command({ buildContext: getBuildContext({ projectDirPath }) });
+            await command({ buildContext: getBuildContext({ projectDirPath }), skipJar });
         }
     });
 


### PR DESCRIPTION
Introduce a new flag for build command `--skip-jar` to skip output as jar file and leave the pre-bundle folder.

I would like to submit this change because We use a different tools to bundle JAR output in our build system.

This will allow little flexibility to bundle the final output.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a --skip-jar option to the build command to skip generating the output JAR.
  - When used, Maven presence checks are bypassed, enabling builds in environments without Maven.
  - Skipping the JAR can speed up development builds; default behavior remains unchanged (JAR is built unless --skip-jar is specified).
  - Clear warning is logged when JAR generation is skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->