### PR TITLE
Fix warning related to hostname v1 feature

### DIFF
--- a/src/bin/start-keycloak/start-keycloak.ts
+++ b/src/bin/start-keycloak/start-keycloak.ts
@@ -559,7 +559,7 @@ export async function command(params: {
             ? [`-e${SPACE_PLACEHOLDER}JAVA_OPTS=-Dkeycloak.profile=preview`]
             : []),
         ...(keycloakMajorVersionNumber < 25
-            ? `-e${SPACE_PLACEHOLDER}KC_HOSTNAME_STRICT_HTTPS=false`
+            ? [`-e${SPACE_PLACEHOLDER}KC_HOSTNAME_STRICT_HTTPS=false`]
             : []),
         ...[
             ...buildContext.themeNames,

--- a/src/bin/start-keycloak/start-keycloak.ts
+++ b/src/bin/start-keycloak/start-keycloak.ts
@@ -558,7 +558,9 @@ export async function command(params: {
         ...(keycloakMajorVersionNumber <= 20
             ? [`-e${SPACE_PLACEHOLDER}JAVA_OPTS=-Dkeycloak.profile=preview`]
             : []),
-        `-e${SPACE_PLACEHOLDER}KC_HOSTNAME_STRICT_HTTPS=false`,
+        ...(keycloakMajorVersionNumber < 25
+            ? `-e${SPACE_PLACEHOLDER}KC_HOSTNAME_STRICT_HTTPS=false`
+            : []),
         ...[
             ...buildContext.themeNames,
             ...(fs.existsSync(


### PR DESCRIPTION
Fix a warning on startup after deprecation of hostname_v1:

Keycloak 25
        - hostname-strict-https: Available only when hostname:v1 feature is enabled.

Keycloak 26
WARNING: Hostname v1 options [hostname-strict-https] are still in use, please review your configuration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Keycloak startup now conditionally includes the HTTPS hostname strictness setting based on the detected major version: it is retained for versions below 25 and omitted for 25 and above. This preserves prior behavior for older releases while improving compatibility and reducing configuration friction with newer Keycloak versions, resulting in smoother, more reliable startups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->