### PR TITLE
 add space between text and link

### DIFF
--- a/src/login/pages/LoginPageExpired.tsx
+++ b/src/login/pages/LoginPageExpired.tsx
@@ -12,15 +12,15 @@ export default function LoginPageExpired(props: PageProps<Extract<KcContext, { p
     return (
         <Template kcContext={kcContext} i18n={i18n} doUseDefaultCss={doUseDefaultCss} classes={classes} headerNode={msg("pageExpiredTitle")}>
             <p id="instruction1" className="instruction">
-                {msg("pageExpiredMsg1")}
+                {msg("pageExpiredMsg1")}{" "}
                 <a id="loginRestartLink" href={url.loginRestartFlowUrl}>
-                    {msg("doClickHere")}{" "}
-                </a>{" "}
+                    {msg("doClickHere")}
+                </a>
                 .<br />
                 {msg("pageExpiredMsg2")}{" "}
                 <a id="loginContinueLink" href={url.loginAction}>
                     {msg("doClickHere")}
-                </a>{" "}
+                </a>
                 .
             </p>
         </Template>


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined spacing and tag placement for links on the Login Expired page to improve text flow and visual consistency.
  * Aligned opening/closing tags and removed stray spaces so “Click here” and “Continue” render cleanly across browsers.
  * No changes to behavior, navigation, or accessibility—purely presentational polish.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

The following image shows the current situation without the fix.
<img width="509" height="386" alt="image" src="https://github.com/user-attachments/assets/4570cdf4-9ddf-4bff-a046-f72b8ab6e3be" />
