### PR TITLE
Added messageFormatter into i18nBuilder and support for choiceFormat

### DIFF
--- a/src/login/i18n/noJsx/formatMessageChoiceFormat.ts
+++ b/src/login/i18n/noJsx/formatMessageChoiceFormat.ts
@@ -1,0 +1,140 @@
+/**
+ * Finds the index of the matching closing brace for the opening brace at the given start index.
+ * @param message whole message string
+ * @param start index of the character after the opening brace
+ */
+function findMatchingBrace(message: string, start: number): number {
+    let depth = 1;
+    let i = start;
+    while (i < message.length && depth > 0) {
+        if (message[i] === "{") depth++;
+        else if (message[i] === "}") depth--;
+        i++;
+    }
+    return depth === 0 ? i : -1;
+}
+
+/**
+ * Splits the inner choice options by the "|" character.
+ * @param inner Inner string containing choice options
+ * @returns Array of choice options
+ */
+function splitChoiceOptions(inner: string): string[] {
+    const options = [];
+    let cur = "";
+    let nested = 0;
+    for (let ch of inner) {
+        if (ch === "{") nested++;
+        else if (ch === "}") nested--;
+        if (ch === "|" && nested === 0) {
+            options.push(cur);
+            cur = "";
+        } else {
+            cur += ch;
+        }
+    }
+    options.push(cur);
+    return options;
+}
+
+/**
+ * Chooses the appropriate option text based on the provided value.
+ * @param options Array of choice options
+ * @param value The value to match against the options
+ * @returns The chosen option text
+ */
+function chooseOption(options: string[], value: number | undefined): string {
+    for (const opt of options) {
+        const optMatch = opt.match(
+            /^\s*([+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)\s*(#|<)([\s\S]*)$/
+        );
+        if (!optMatch) continue;
+        const limit = Number(optMatch[1]);
+        const op = optMatch[2];
+        const text = optMatch[3];
+        if (
+            (op === "#" && value === limit) ||
+            (op === "<" && (!value || value > limit))
+        ) {
+            return text;
+        }
+    }
+    // fallback to last option's text if nothing matched
+    const lastOpt = options[options.length - 1] || "";
+    return lastOpt.replace(/^\s*([+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)\s*(#|<)/, "");
+}
+
+/**
+ * Replaces simple placeholders in the message with the corresponding arguments.
+ * @param result The current result string
+ * @param message The original message string
+ * @param args The arguments to replace placeholders with
+ * @param startIndex The starting index for replacement
+ * @returns The updated result string
+ */
+function replaceSimplePlaceholders(
+    result: string,
+    message: string,
+    args: any[] | undefined,
+    startIndex: number | undefined
+): string {
+    const simplePlaceholderStartIndex = message
+        .match(/{[0-9]+}/g)
+        ?.map(g => g.match(/{([0-9]+)}/)![1])
+        .map(indexStr => parseInt(indexStr))
+        .sort((a, b) => a - b)[0];
+
+    if (startIndex === undefined || startIndex > simplePlaceholderStartIndex!) {
+        startIndex = simplePlaceholderStartIndex!;
+    }
+
+    args?.forEach((arg, i) => {
+        if (arg === undefined || startIndex === undefined) {
+            return;
+        }
+        result = result.replace(new RegExp(`\\{${i + startIndex}\\}`, "g"), arg);
+    });
+    return result;
+}
+
+/**
+ * Formats a message by replacing placeholders and choice format with the corresponding arguments.
+ * @param message The original message string
+ * @param args The arguments to replace placeholders with
+ * @returns The formatted message string
+ */
+export function formatChoiceMessage(message: string, args?: any[]): string {
+    let result = "";
+    let startIndex: number | undefined;
+    let lastIndex = 0;
+    const openerRegex = /\{\s*(\d+)\s*,\s*choice\s*,/g;
+    let m;
+
+    while ((m = openerRegex.exec(message)) !== null) {
+        const start = m.index;
+        const argIndex = Number(m[1]);
+        if (startIndex === undefined || startIndex > argIndex) {
+            startIndex = argIndex;
+        }
+        result += message.slice(lastIndex, start);
+
+        const innerStart = start + m[0].length;
+        const end = findMatchingBrace(message, innerStart);
+        if (end === -1) {
+            result += message.slice(start);
+            lastIndex = message.length;
+            break;
+        }
+        const inner = message.slice(innerStart, end - 1);
+        const options = splitChoiceOptions(inner);
+        const value = args ? Number(args[argIndex]) : undefined;
+        const chosenText = chooseOption(options, value);
+        result += chosenText;
+        lastIndex = end;
+        openerRegex.lastIndex = lastIndex;
+    }
+
+    result += message.slice(lastIndex);
+    result = replaceSimplePlaceholders(result, message, args, startIndex);
+    return result;
+}

--- a/src/login/i18n/noJsx/formatMessageChoiceFormat.ts
+++ b/src/login/i18n/noJsx/formatMessageChoiceFormat.ts
@@ -52,10 +52,10 @@ function chooseOption(options: string[], value: number | undefined): string {
         const limit = Number(optMatch[1]);
         const op = optMatch[2];
         const text = optMatch[3];
-        if (
-            (op === "#" && value === limit) ||
-            (op === "<" && (!value || value > limit))
-        ) {
+        if (value === undefined) {
+            continue;
+        }
+        if ((op === "#" && value <= limit) || (op === "<" && value > limit)) {
             return text;
         }
     }

--- a/src/login/i18n/noJsx/getI18n.tsx
+++ b/src/login/i18n/noJsx/getI18n.tsx
@@ -15,7 +15,7 @@ import {
 import type { GenericI18n_noJsx } from "./GenericI18n_noJsx";
 import { formatChoiceMessage } from "./formatMessageChoiceFormat";
 
-export type MessageFormatter = (message: string, args: (any | undefined)[]) => string;
+export type MessageFormatter = (message: string, args: (unknown | undefined)[]) => string;
 
 export type KcContextLike = {
     themeName: string;
@@ -350,9 +350,12 @@ function createI18nTranslationFunctionsFactory<MessageKey_themeDefined extends s
             }
 
             if (messageFormatter) {
-                return messageFormatter(message, args);
+                try {
+                    return messageFormatter(message, args);
+                } catch (e) {
+                    console.warn("keycloakify:i18n messageFormatter error; falling back to ChoiceFormat", e);
+                }
             }
-
             return formatChoiceMessage(message, args);
         }
 

--- a/src/login/i18n/noJsx/i18nBuilder.ts
+++ b/src/login/i18n/noJsx/i18nBuilder.ts
@@ -59,8 +59,8 @@ export type I18nBuilder<
             MessageFormatter,
             ExcludedMethod | "withCustomTranslations"
         >;
-        withMessageFormatter: (
-            formatter: (message: string, args: (string | undefined)[]) => string
+        withMessageFormatter: <MessageFormatter extends MessageFormatter_I18n>(
+            formatter: MessageFormatter
         ) => I18nBuilder<
             ThemeName,
             MessageKey_themeDefined,
@@ -113,18 +113,21 @@ function createI18nBuilder<
             createI18nBuilder({
                 extraLanguageTranslations: params.extraLanguageTranslations,
                 messagesByLanguageTag_themeDefined:
-                    params.messagesByLanguageTag_themeDefined as any
+                    params.messagesByLanguageTag_themeDefined as any,
+                messageFormatter: params.messageFormatter
             }),
         withExtraLanguages: extraLanguageTranslations =>
             createI18nBuilder({
                 extraLanguageTranslations,
                 messagesByLanguageTag_themeDefined:
-                    params.messagesByLanguageTag_themeDefined as any
+                    params.messagesByLanguageTag_themeDefined as any,
+                messageFormatter: params.messageFormatter
             }),
         withCustomTranslations: messagesByLanguageTag_themeDefined =>
             createI18nBuilder({
                 extraLanguageTranslations: params.extraLanguageTranslations,
-                messagesByLanguageTag_themeDefined
+                messagesByLanguageTag_themeDefined,
+                messageFormatter: params.messageFormatter
             }),
         withMessageFormatter: formatter =>
             createI18nBuilder({

--- a/src/login/i18n/noJsx/i18nBuilder.ts
+++ b/src/login/i18n/noJsx/i18nBuilder.ts
@@ -2,22 +2,29 @@ import type {
     LanguageTag as LanguageTag_defaultSet,
     MessageKey as MessageKey_defaultSet
 } from "../messages_defaultSet/types";
-import { type ReturnTypeOfCreateGetI18n, createGetI18n } from "./getI18n";
+import {
+    type ReturnTypeOfCreateGetI18n,
+    type MessageFormatter as MessageFormatter_I18n,
+    createGetI18n
+} from "./getI18n";
 
 export type I18nBuilder<
     ThemeName extends string = never,
     MessageKey_themeDefined extends string = never,
     LanguageTag_notInDefaultSet extends string = never,
+    MessageFormatter extends MessageFormatter_I18n = never,
     ExcludedMethod extends
         | "withThemeName"
         | "withExtraLanguages"
-        | "withCustomTranslations" = never
+        | "withCustomTranslations"
+        | "withMessageFormatter" = never
 > = Omit<
     {
         withThemeName: <ThemeName extends string>() => I18nBuilder<
             ThemeName,
             MessageKey_themeDefined,
             LanguageTag_notInDefaultSet,
+            MessageFormatter,
             ExcludedMethod | "withThemeName"
         >;
         withExtraLanguages: <
@@ -33,6 +40,7 @@ export type I18nBuilder<
             ThemeName,
             MessageKey_themeDefined,
             LanguageTag_notInDefaultSet,
+            MessageFormatter,
             ExcludedMethod | "withExtraLanguages"
         >;
         withCustomTranslations: <MessageKey_themeDefined extends string>(
@@ -48,7 +56,17 @@ export type I18nBuilder<
             ThemeName,
             MessageKey_themeDefined,
             LanguageTag_notInDefaultSet,
+            MessageFormatter,
             ExcludedMethod | "withCustomTranslations"
+        >;
+        withMessageFormatter: (
+            formatter: (message: string, args: (string | undefined)[]) => string
+        ) => I18nBuilder<
+            ThemeName,
+            MessageKey_themeDefined,
+            LanguageTag_notInDefaultSet,
+            MessageFormatter,
+            ExcludedMethod | "withMessageFormatter"
         >;
         build: () => ReturnTypeOfCreateGetI18n<
             MessageKey_themeDefined,
@@ -61,7 +79,8 @@ export type I18nBuilder<
 function createI18nBuilder<
     ThemeName extends string = never,
     MessageKey_themeDefined extends string = never,
-    LanguageTag_notInDefaultSet extends string = never
+    LanguageTag_notInDefaultSet extends string = never,
+    MessageFormatter extends MessageFormatter_I18n = never
 >(params: {
     extraLanguageTranslations: {
         [LanguageTag in LanguageTag_notInDefaultSet]: {
@@ -77,11 +96,18 @@ function createI18nBuilder<
             string | Record<ThemeName, string>
         >;
     }>;
-}): I18nBuilder<ThemeName, MessageKey_themeDefined, LanguageTag_notInDefaultSet> {
+    messageFormatter?: MessageFormatter;
+}): I18nBuilder<
+    ThemeName,
+    MessageKey_themeDefined,
+    LanguageTag_notInDefaultSet,
+    MessageFormatter
+> {
     const i18nBuilder: I18nBuilder<
         ThemeName,
         MessageKey_themeDefined,
-        LanguageTag_notInDefaultSet
+        LanguageTag_notInDefaultSet,
+        MessageFormatter
     > = {
         withThemeName: () =>
             createI18nBuilder({
@@ -100,11 +126,19 @@ function createI18nBuilder<
                 extraLanguageTranslations: params.extraLanguageTranslations,
                 messagesByLanguageTag_themeDefined
             }),
+        withMessageFormatter: formatter =>
+            createI18nBuilder({
+                extraLanguageTranslations: params.extraLanguageTranslations,
+                messagesByLanguageTag_themeDefined:
+                    params.messagesByLanguageTag_themeDefined,
+                messageFormatter: formatter
+            }),
         build: () =>
             createGetI18n({
                 extraLanguageTranslations: params.extraLanguageTranslations,
                 messagesByLanguageTag_themeDefined:
-                    params.messagesByLanguageTag_themeDefined
+                    params.messagesByLanguageTag_themeDefined,
+                messageFormatter: params.messageFormatter
             })
     };
 

--- a/src/login/i18n/noJsx/index.ts
+++ b/src/login/i18n/noJsx/index.ts
@@ -1,3 +1,4 @@
 export { i18nBuilder } from "./i18nBuilder";
+export { formatChoiceMessage } from "./formatMessageChoiceFormat";
 export type { KcContextLike } from "./getI18n";
 export type { MessageKey as MessageKey_defaultSet } from "../messages_defaultSet/types";

--- a/src/login/i18n/withJsx/i18nBuilder.ts
+++ b/src/login/i18n/withJsx/i18nBuilder.ts
@@ -59,8 +59,8 @@ export type I18nBuilder<
             MessageFormatter,
             ExcludedMethod | "withCustomTranslations"
         >;
-        withMessageFormatter: (
-            formatter: (message: string, args: (string | undefined)[]) => string
+        withMessageFormatter: <MessageFormatter extends MessageFormatter_I18n>(
+            formatter: MessageFormatter
         ) => I18nBuilder<
             ThemeName,
             MessageKey_themeDefined,

--- a/src/login/i18n/withJsx/i18nBuilder.ts
+++ b/src/login/i18n/withJsx/i18nBuilder.ts
@@ -2,22 +2,29 @@ import type {
     LanguageTag as LanguageTag_defaultSet,
     MessageKey as MessageKey_defaultSet
 } from "../messages_defaultSet/types";
-import { type ReturnTypeOfCreateUseI18n, createUseI18n } from "../withJsx/useI18n";
+import {
+    type ReturnTypeOfCreateUseI18n,
+    type MessageFormatter as MessageFormatter_I18n,
+    createUseI18n
+} from "../withJsx/useI18n";
 
 export type I18nBuilder<
     ThemeName extends string = never,
     MessageKey_themeDefined extends string = never,
     LanguageTag_notInDefaultSet extends string = never,
+    MessageFormatter extends MessageFormatter_I18n = never,
     ExcludedMethod extends
         | "withThemeName"
         | "withExtraLanguages"
-        | "withCustomTranslations" = never
+        | "withCustomTranslations"
+        | "withMessageFormatter" = never
 > = Omit<
     {
         withThemeName: <ThemeName extends string>() => I18nBuilder<
             ThemeName,
             MessageKey_themeDefined,
             LanguageTag_notInDefaultSet,
+            MessageFormatter,
             ExcludedMethod | "withThemeName"
         >;
         withExtraLanguages: <
@@ -33,6 +40,7 @@ export type I18nBuilder<
             ThemeName,
             MessageKey_themeDefined,
             LanguageTag_notInDefaultSet,
+            MessageFormatter,
             ExcludedMethod | "withExtraLanguages"
         >;
         withCustomTranslations: <MessageKey_themeDefined extends string>(
@@ -48,7 +56,17 @@ export type I18nBuilder<
             ThemeName,
             string extends MessageKey_themeDefined ? never : MessageKey_themeDefined,
             LanguageTag_notInDefaultSet,
+            MessageFormatter,
             ExcludedMethod | "withCustomTranslations"
+        >;
+        withMessageFormatter: (
+            formatter: (message: string, args: (string | undefined)[]) => string
+        ) => I18nBuilder<
+            ThemeName,
+            MessageKey_themeDefined,
+            LanguageTag_notInDefaultSet,
+            MessageFormatter,
+            ExcludedMethod | "withMessageFormatter"
         >;
         build: () => ReturnTypeOfCreateUseI18n<
             MessageKey_themeDefined,
@@ -61,7 +79,8 @@ export type I18nBuilder<
 function createI18nBuilder<
     ThemeName extends string = never,
     MessageKey_themeDefined extends string = never,
-    LanguageTag_notInDefaultSet extends string = never
+    LanguageTag_notInDefaultSet extends string = never,
+    MessageFormatter extends MessageFormatter_I18n = never
 >(params: {
     extraLanguageTranslations: {
         [LanguageTag in LanguageTag_notInDefaultSet]: {
@@ -77,34 +96,52 @@ function createI18nBuilder<
             string | Record<ThemeName, string>
         >;
     }>;
-}): I18nBuilder<ThemeName, MessageKey_themeDefined, LanguageTag_notInDefaultSet> {
+    messageFormatter?: MessageFormatter;
+}): I18nBuilder<
+    ThemeName,
+    MessageKey_themeDefined,
+    LanguageTag_notInDefaultSet,
+    MessageFormatter
+> {
     const i18nBuilder: I18nBuilder<
         ThemeName,
         MessageKey_themeDefined,
-        LanguageTag_notInDefaultSet
+        LanguageTag_notInDefaultSet,
+        MessageFormatter
     > = {
         withThemeName: () =>
             createI18nBuilder({
                 extraLanguageTranslations: params.extraLanguageTranslations,
                 messagesByLanguageTag_themeDefined:
-                    params.messagesByLanguageTag_themeDefined as any
+                    params.messagesByLanguageTag_themeDefined as any,
+                messageFormatter: params.messageFormatter
             }),
         withExtraLanguages: extraLanguageTranslations =>
             createI18nBuilder({
                 extraLanguageTranslations,
                 messagesByLanguageTag_themeDefined:
-                    params.messagesByLanguageTag_themeDefined as any
+                    params.messagesByLanguageTag_themeDefined as any,
+                messageFormatter: params.messageFormatter
             }),
         withCustomTranslations: messagesByLanguageTag_themeDefined =>
             createI18nBuilder({
                 extraLanguageTranslations: params.extraLanguageTranslations,
-                messagesByLanguageTag_themeDefined
+                messagesByLanguageTag_themeDefined,
+                messageFormatter: params.messageFormatter
+            }),
+        withMessageFormatter: messageFormatter =>
+            createI18nBuilder({
+                extraLanguageTranslations: params.extraLanguageTranslations,
+                messagesByLanguageTag_themeDefined:
+                    params.messagesByLanguageTag_themeDefined,
+                messageFormatter
             }),
         build: () =>
             createUseI18n({
                 extraLanguageTranslations: params.extraLanguageTranslations,
                 messagesByLanguageTag_themeDefined:
-                    params.messagesByLanguageTag_themeDefined
+                    params.messagesByLanguageTag_themeDefined,
+                messageFormatter: params.messageFormatter
             })
     };
 

--- a/src/login/i18n/withJsx/useI18n.tsx
+++ b/src/login/i18n/withJsx/useI18n.tsx
@@ -1,7 +1,7 @@
 import type { JSX } from "keycloakify/tools/JSX";
 import { useEffect, useState } from "react";
 import { kcSanitize } from "keycloakify/lib/kcSanitize";
-import { createGetI18n, type KcContextLike } from "../noJsx/getI18n";
+import { createGetI18n, type KcContextLike, type MessageFormatter as MessageFormatter_I18n } from "../noJsx/getI18n";
 import type { GenericI18n_noJsx } from "../noJsx/GenericI18n_noJsx";
 import { Reflect } from "tsafe/Reflect";
 import type { GenericI18n } from "./GenericI18n";
@@ -16,10 +16,13 @@ export type ReturnTypeOfCreateUseI18n<MessageKey_themeDefined extends string, La
 
 export { KcContextLike };
 
+export { MessageFormatter_I18n as MessageFormatter };
+
 export function createUseI18n<
     ThemeName extends string = string,
     MessageKey_themeDefined extends string = never,
-    LanguageTag_notInDefaultSet extends string = never
+    LanguageTag_notInDefaultSet extends string = never,
+    MessageFormatter extends MessageFormatter_I18n = never
 >(params: {
     extraLanguageTranslations: {
         [languageTag in LanguageTag_notInDefaultSet]: {
@@ -32,8 +35,9 @@ export function createUseI18n<
             [key in MessageKey_themeDefined]: string | Record<ThemeName, string>;
         };
     }>;
+    messageFormatter?: MessageFormatter;
 }): ReturnTypeOfCreateUseI18n<MessageKey_themeDefined, LanguageTag_notInDefaultSet> {
-    const { extraLanguageTranslations, messagesByLanguageTag_themeDefined } = params;
+    const { extraLanguageTranslations, messagesByLanguageTag_themeDefined, messageFormatter } = params;
 
     type LanguageTag = LanguageTag_defaultSet | LanguageTag_notInDefaultSet;
 
@@ -111,7 +115,7 @@ export function createUseI18n<
         document.head.prepend(styleElement);
     }
 
-    const { getI18n } = createGetI18n({ extraLanguageTranslations, messagesByLanguageTag_themeDefined });
+    const { getI18n } = createGetI18n({ extraLanguageTranslations, messagesByLanguageTag_themeDefined, messageFormatter });
 
     function useI18n(params: { kcContext: KcContextLike }): Result {
         const { kcContext } = params;

--- a/test/login/formatMessageChoiceFormat.spec.ts
+++ b/test/login/formatMessageChoiceFormat.spec.ts
@@ -307,5 +307,23 @@ describe("formatChoiceMessage", () => {
         ).toEqual(
             "Message with multiple multiple items choice placeholders: first multiple items, second multiple items."
         );
+
+        expect(
+            formatChoiceMessage("{0,choice,5#five|10#ten|10<more than ten}", [7])
+        ).toEqual("ten");
+
+        expect(
+            formatChoiceMessage("{0,choice,5#five|10#ten|10<more than ten}", [-1])
+        ).toEqual("five");
+
+        expect(
+            formatChoiceMessage("{0,choice,5#five|10#ten|10<more than ten}", [5.6])
+        ).toEqual("ten");
+
+        expect(formatChoiceMessage("{0} {10}", [1])).toEqual("1 {10}");
+
+        expect(
+            formatChoiceMessage("{0} {10}", [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11])
+        ).toEqual("1 11");
     });
 });

--- a/test/login/formatMessageChoiceFormat.spec.ts
+++ b/test/login/formatMessageChoiceFormat.spec.ts
@@ -1,0 +1,311 @@
+import { formatChoiceMessage } from "keycloakify/login/i18n/noJsx";
+import { expect, it, describe } from "vitest";
+
+describe("formatChoiceMessage", () => {
+    it("Formatting without args", () => {
+        expect(formatChoiceMessage("Simple message without placeholders.")).toEqual(
+            "Simple message without placeholders."
+        );
+
+        expect(formatChoiceMessage("Message with {0} simple placeholder.")).toEqual(
+            "Message with {0} simple placeholder."
+        );
+
+        expect(
+            formatChoiceMessage("Message with {0} and {1} simple placeholders.")
+        ).toEqual("Message with {0} and {1} simple placeholders.");
+
+        expect(
+            formatChoiceMessage(
+                "Message with {0, choice, 0#no items|1#one item|2#multiple items} choice placeholder."
+            )
+        ).toEqual("Message with multiple items choice placeholder.");
+
+        expect(
+            formatChoiceMessage(
+                "Message with {0      ,     choice     , 0#     no items     |1#one item|2#multiple items} choice placeholder and spaces inside of them."
+            )
+        ).toEqual(
+            "Message with multiple items choice placeholder and spaces inside of them."
+        );
+
+        expect(
+            formatChoiceMessage(
+                "Message with {0, choice, 0#no items|1#one item|2# {0} items} choice placeholder and nested {0} simple placeholder."
+            )
+        ).toEqual(
+            "Message with  {0} items choice placeholder and nested {0} simple placeholder."
+        );
+
+        expect(
+            formatChoiceMessage(
+                "Message with {0, choice, 0#no items|1#one item|2#multiple items} choice placeholder and {1} simple placeholder."
+            )
+        ).toEqual(
+            "Message with multiple items choice placeholder and {1} simple placeholder."
+        );
+
+        expect(
+            formatChoiceMessage(
+                "Message with {0, choice, 0#no items|1#one item|2# {0} items} choice placeholder with nested {0} simple placeholder and {1} simple placeholder."
+            )
+        ).toEqual(
+            "Message with  {0} items choice placeholder with nested {0} simple placeholder and {1} simple placeholder."
+        );
+
+        expect(
+            formatChoiceMessage(
+                "Message with multiple {0, choice, 0#no items|1#one item|2#multiple items} choice placeholders: first {0, choice, 0#no items|1#one item|2#multiple items}, second {0, choice, 0#no items|1#one item|2#multiple items}."
+            )
+        ).toEqual(
+            "Message with multiple multiple items choice placeholders: first multiple items, second multiple items."
+        );
+    });
+
+    it("Formatting with invalid arguments", () => {
+        expect(formatChoiceMessage("Simple message without placeholders.", [])).toEqual(
+            "Simple message without placeholders."
+        );
+
+        expect(
+            formatChoiceMessage("Message with {0} simple placeholder.", [undefined])
+        ).toEqual("Message with {0} simple placeholder.");
+
+        expect(
+            formatChoiceMessage("Message with {0} and {1} simple placeholders.", [
+                undefined,
+                undefined
+            ])
+        ).toEqual("Message with {0} and {1} simple placeholders.");
+
+        expect(
+            formatChoiceMessage(
+                "Message with {0, choice, 0#no items|1#one item|2#multiple items} choice placeholder.",
+                ["text"]
+            )
+        ).toEqual("Message with multiple items choice placeholder.");
+
+        expect(
+            formatChoiceMessage(
+                "Message with {0      ,     choice     , 0#     no items     |1#one item|2#multiple items} choice placeholder and spaces inside of them.",
+                [NaN]
+            )
+        ).toEqual(
+            "Message with multiple items choice placeholder and spaces inside of them."
+        );
+
+        expect(
+            formatChoiceMessage(
+                "Message with {0, choice, 0#no items|1#one item|2# {0} items} choice placeholder and nested {0} simple placeholder.",
+                []
+            )
+        ).toEqual(
+            "Message with  {0} items choice placeholder and nested {0} simple placeholder."
+        );
+
+        expect(
+            formatChoiceMessage(
+                "Message with {0, choice, 0#no items|1#one item|2#multiple items} choice placeholder and {1} simple placeholder.",
+                [null, undefined]
+            )
+        ).toEqual("Message with no items choice placeholder and {1} simple placeholder.");
+
+        expect(
+            formatChoiceMessage(
+                "Message with {0, choice, 0#no items|1#one item|2# {0} items} choice placeholder with nested {0} simple placeholder and {1} simple placeholder.",
+                ["text", "more text"]
+            )
+        ).toEqual(
+            "Message with  text items choice placeholder with nested text simple placeholder and more text simple placeholder."
+        );
+
+        expect(
+            formatChoiceMessage(
+                "Message with multiple {0, choice, 0#no items|1#one item|2#multiple items} choice placeholders: first {0, choice, 0#no items|1#one item|2#multiple items}, second {0, choice, 0#no items|1#one item|2#multiple items}.",
+                []
+            )
+        ).toEqual(
+            "Message with multiple multiple items choice placeholders: first multiple items, second multiple items."
+        );
+    });
+
+    it("Formatting with valid arguments", () => {
+        expect(formatChoiceMessage("Simple message without placeholders.", [])).toEqual(
+            "Simple message without placeholders."
+        );
+
+        expect(formatChoiceMessage("Message with {0} simple placeholder.", [1])).toEqual(
+            "Message with 1 simple placeholder."
+        );
+
+        expect(
+            formatChoiceMessage("Message with {0} and {1} simple placeholders.", [2, 3])
+        ).toEqual("Message with 2 and 3 simple placeholders.");
+
+        expect(
+            formatChoiceMessage(
+                "Message with {0, choice, 0#no items|1#one item|2#multiple items} choice placeholder.",
+                [0]
+            )
+        ).toEqual("Message with no items choice placeholder.");
+
+        expect(
+            formatChoiceMessage(
+                "Message with {0, choice, 0#no items|1#one item|2#multiple items} choice placeholder.",
+                [1]
+            )
+        ).toEqual("Message with one item choice placeholder.");
+
+        expect(
+            formatChoiceMessage(
+                "Message with {0, choice, 0#no items|1#one item|2#multiple items} choice placeholder.",
+                [2]
+            )
+        ).toEqual("Message with multiple items choice placeholder.");
+
+        expect(
+            formatChoiceMessage(
+                "Message with {0, choice, 0#no items|1#one item|2#multiple items|2<{0} items} choice placeholder.",
+                [4]
+            )
+        ).toEqual("Message with 4 items choice placeholder.");
+
+        expect(
+            formatChoiceMessage(
+                "Message with {0      ,     choice     , 0#     no items     |1#one item|2#multiple items} choice placeholder and spaces inside of them.",
+                [0]
+            )
+        ).toEqual(
+            "Message with      no items      choice placeholder and spaces inside of them."
+        );
+
+        expect(
+            formatChoiceMessage(
+                "Message with {0      ,     choice     , 0#     no items     |1#one item|2#multiple items} choice placeholder and spaces inside of them.",
+                [1]
+            )
+        ).toEqual("Message with one item choice placeholder and spaces inside of them.");
+
+        expect(
+            formatChoiceMessage(
+                "Message with {0      ,     choice     , 0#     no items     |1#one item|2#multiple items} choice placeholder and spaces inside of them.",
+                [2]
+            )
+        ).toEqual(
+            "Message with multiple items choice placeholder and spaces inside of them."
+        );
+
+        expect(
+            formatChoiceMessage(
+                "Message with {0, choice, 0#no items|1#one item|2# {0} items} choice placeholder and nested {0} simple placeholder.",
+                [0]
+            )
+        ).toEqual(
+            "Message with no items choice placeholder and nested 0 simple placeholder."
+        );
+
+        expect(
+            formatChoiceMessage(
+                "Message with {0, choice, 0#no items|1#one item|2# {0} items} choice placeholder and nested {0} simple placeholder.",
+                [1]
+            )
+        ).toEqual(
+            "Message with one item choice placeholder and nested 1 simple placeholder."
+        );
+
+        expect(
+            formatChoiceMessage(
+                "Message with {0, choice, 0#no items|1#one item|2< {0} items} choice placeholder and nested {0} simple placeholder.",
+                [2]
+            )
+        ).toEqual(
+            "Message with  2 items choice placeholder and nested 2 simple placeholder."
+        );
+
+        expect(
+            formatChoiceMessage(
+                "Message with {0, choice, 0#no items|1#one item|4< {0} items} choice placeholder and nested {0} simple placeholder.",
+                [4]
+            )
+        ).toEqual(
+            "Message with  4 items choice placeholder and nested 4 simple placeholder."
+        );
+
+        expect(
+            formatChoiceMessage(
+                "Message with {0, choice, 0#no items|1#one item|2#multiple items} choice placeholder and {1} simple placeholder.",
+                [0, 0]
+            )
+        ).toEqual("Message with no items choice placeholder and 0 simple placeholder.");
+
+        expect(
+            formatChoiceMessage(
+                "Message with {0, choice, 0#no items|1#one item|2#multiple items} choice placeholder and {1} simple placeholder.",
+                [1, 0]
+            )
+        ).toEqual("Message with one item choice placeholder and 0 simple placeholder.");
+
+        expect(
+            formatChoiceMessage(
+                "Message with {0, choice, 0#no items|1#one item|2#multiple items} choice placeholder and {1} simple placeholder.",
+                [2, 0]
+            )
+        ).toEqual(
+            "Message with multiple items choice placeholder and 0 simple placeholder."
+        );
+
+        expect(
+            formatChoiceMessage(
+                "Message with {0, choice, 0#no items|1#one item|2# {0} items} choice placeholder with nested {0} simple placeholder and {1} simple placeholder.",
+                [0, "more text"]
+            )
+        ).toEqual(
+            "Message with no items choice placeholder with nested 0 simple placeholder and more text simple placeholder."
+        );
+
+        expect(
+            formatChoiceMessage(
+                "Message with {0, choice, 0#no items|1#one item|2# {0} items} choice placeholder with nested {0} simple placeholder and {1} simple placeholder.",
+                [1, "more text"]
+            )
+        ).toEqual(
+            "Message with one item choice placeholder with nested 1 simple placeholder and more text simple placeholder."
+        );
+
+        expect(
+            formatChoiceMessage(
+                "Message with {0, choice, 0#no items|1#one item|2# {0} items} choice placeholder with nested {0} simple placeholder and {1} simple placeholder.",
+                [2, "more text"]
+            )
+        ).toEqual(
+            "Message with  2 items choice placeholder with nested 2 simple placeholder and more text simple placeholder."
+        );
+
+        expect(
+            formatChoiceMessage(
+                "Message with multiple {0, choice, 0#no items|1#one item|2#multiple items} choice placeholders: first {0, choice, 0#no items|1#one item|2#multiple items}, second {0, choice, 0#no items|1#one item|2#multiple items}.",
+                [0]
+            )
+        ).toEqual(
+            "Message with multiple no items choice placeholders: first no items, second no items."
+        );
+
+        expect(
+            formatChoiceMessage(
+                "Message with multiple {0, choice, 0#no items|1#one item|2#multiple items} choice placeholders: first {0, choice, 0#no items|1#one item|2#multiple items}, second {0, choice, 0#no items|1#one item|2#multiple items}.",
+                [1]
+            )
+        ).toEqual(
+            "Message with multiple one item choice placeholders: first one item, second one item."
+        );
+
+        expect(
+            formatChoiceMessage(
+                "Message with multiple {0, choice, 0#no items|1#one item|2#multiple items} choice placeholders: first {0, choice, 0#no items|1#one item|2#multiple items}, second {0, choice, 0#no items|1#one item|2#multiple items}.",
+                [2]
+            )
+        ).toEqual(
+            "Message with multiple multiple items choice placeholders: first multiple items, second multiple items."
+        );
+    });
+});

--- a/test/login/i18n.typelevel-spec.ts
+++ b/test/login/i18n.typelevel-spec.ts
@@ -124,3 +124,26 @@ i18nBuilder
             //myCustomKey2: "my-custom-key-2-he"
         }
     });
+
+i18nBuilder
+    .withThemeName<"my-theme-1" | "my-theme-2">()
+    .withExtraLanguages({
+        he: {
+            label: "עברית",
+            getMessages: () => import("./he")
+        }
+    })
+    .withCustomTranslations({
+        en: {
+            myCustomKey1: "my-custom-key-1-en",
+            myCustomKey2: "my-custom-key-2-en"
+        },
+        // @ts-expect-error
+        he: {
+            myCustomKey1: "my-custom-key-1-he"
+            //myCustomKey2: "my-custom-key-2-he"
+        }
+    })
+    .withMessageFormatter((msg, _args) => {
+        return msg;
+    });


### PR DESCRIPTION
Fixes #938 by adding support for messageFormatter function into i18n using withMessageFormatter in i18nBuilder, and adding support for choiceFormat message format used in keycloak translations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ICU-style choice message formatting and exposed a formatChoiceMessage API.
  * Introduced an optional custom message formatter configurable via the i18n builder/creation flow.

* **Tests**
  * Added comprehensive tests covering choice formatting, nested placeholders, and various argument scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->