### PR TITLE
Add more input types to LoginUpdateProfile

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "keycloakify",
-    "version": "11.14.1",
+    "version": "11.14.2",
     "description": "Framework to create custom Keycloak UIs",
     "repository": {
         "type": "git",

--- a/src/bin/tools/npmInstall.ts
+++ b/src/bin/tools/npmInstall.ts
@@ -18,34 +18,34 @@ export async function npmInstall(params: { packageJsonDirPath: string }) {
         const packageMangers = [
             {
                 binName: "yarn",
-                lockFileBasename: "yarn.lock"
+                lockFileBasenames: ["yarn.lock"]
             },
             {
                 binName: "npm",
-                lockFileBasename: "package-lock.json"
+                lockFileBasenames: ["package-lock.json"]
             },
             {
                 binName: "pnpm",
-                lockFileBasename: "pnpm-lock.yaml"
+                lockFileBasenames: ["pnpm-lock.yaml"]
             },
             {
                 binName: "bun",
-                lockFileBasename: "bun.lockdb"
+                lockFileBasenames: ["bun.lockdb", "bun.lockb", "bun.lock"]
             },
             {
                 binName: "deno",
-                lockFileBasename: "deno.lock"
+                lockFileBasenames: ["deno.lock"]
             }
         ] as const;
 
-        for (const packageManager of packageMangers) {
-            if (
-                fs.existsSync(
-                    pathJoin(packageJsonDirPath, packageManager.lockFileBasename)
-                ) ||
-                fs.existsSync(pathJoin(process.cwd(), packageManager.lockFileBasename))
-            ) {
-                return packageManager.binName;
+        for (const { binName, lockFileBasenames } of packageMangers) {
+            for (const lockFileBasename of lockFileBasenames) {
+                if (
+                    fs.existsSync(pathJoin(packageJsonDirPath, lockFileBasename)) ||
+                    fs.existsSync(pathJoin(process.cwd(), lockFileBasename))
+                ) {
+                    return binName;
+                }
             }
         }
 

--- a/stories/login/pages/LoginUpdateProfile.stories.tsx
+++ b/stories/login/pages/LoginUpdateProfile.stories.tsx
@@ -73,6 +73,42 @@ export const WithMoreFields: Story = {
                             multivalued: false,
                             readOnly: false,
                             name: "favouritePet"
+                        },
+                        age: {
+                            validators: {
+                                multivalued: {
+                                    max: "1"
+                                },
+                                integer: {
+                                    min: 0,
+                                    max: 99
+                                }
+                            },
+                            displayName: "Age",
+                            values: [],
+                            annotations: {
+                                inputType: "html5-number"
+                            },
+                            required: false,
+                            multivalued: false,
+                            readOnly: false,
+                            name: "age"
+                        },
+                        birthdate: {
+                            validators: {
+                                multivalued: {
+                                    max: 1
+                                }
+                            },
+                            displayName: "Birthdate",
+                            values: [],
+                            annotations: {
+                                inputType: "html5-date"
+                            },
+                            required: false,
+                            multivalued: false,
+                            readOnly: false,
+                            name: "birthdate"
                         }
                     }
                 }

--- a/stories/login/pages/LoginUpdateProfile.stories.tsx
+++ b/stories/login/pages/LoginUpdateProfile.stories.tsx
@@ -80,3 +80,33 @@ export const WithMoreFields: Story = {
         />
     )
 };
+
+export const WithGroups: Story = {
+    render: () => (
+        <KcPageStory
+            kcContext={{
+                profile: {
+                    attributesByName: {
+                        cardId: {
+                            validators: {},
+                            displayName: "Division",
+                            annotations: {},
+                            required: false,
+                            html5DataAnnotations: {},
+                            group: {
+                                displayDescription: "Attributes, which refer to user metadata",
+                                annotations: {},
+                                displayHeader: "User metadata",
+                                html5DataAnnotations: {},
+                                name: "user-metadata"
+                            },
+                            multivalued: false,
+                            readOnly: false,
+                            name: "divison"
+                        }
+                    }
+                }
+            }}
+        />
+    )
+};

--- a/stories/login/pages/LoginUpdateProfile.stories.tsx
+++ b/stories/login/pages/LoginUpdateProfile.stories.tsx
@@ -173,7 +173,7 @@ export const WithGroups: Story = {
                             },
                             multivalued: false,
                             readOnly: false,
-                            name: "divison"
+                            name: "division"
                         }
                     }
                 }

--- a/stories/login/pages/LoginUpdateProfile.stories.tsx
+++ b/stories/login/pages/LoginUpdateProfile.stories.tsx
@@ -50,64 +50,99 @@ export const WithMoreFields: Story = {
                             validators: {},
                             displayName: "Multi-Attribute Field",
                             annotations: {},
-                            required: false,
                             multivalued: true,
-                            readOnly: false,
                             name: "multiAttribute"
                         },
                         favouritePet: {
                             validators: {
                                 options: {
                                     options: ["Cat", "Dog", "Bird"]
-                                },
-                                multivalued: {
-                                    max: "1"
                                 }
                             },
                             displayName: "Favourite Pet",
-                            values: [],
                             annotations: {
                                 inputType: "select"
                             },
-                            required: false,
-                            multivalued: false,
-                            readOnly: false,
+                            value: "dog",
+                            values: ["dog"],
                             name: "favouritePet"
                         },
                         age: {
                             validators: {
-                                multivalued: {
-                                    max: "1"
-                                },
                                 integer: {
                                     min: 0,
                                     max: 99
                                 }
                             },
                             displayName: "Age",
-                            values: [],
                             annotations: {
                                 inputType: "html5-number"
                             },
-                            required: false,
-                            multivalued: false,
-                            readOnly: false,
                             name: "age"
                         },
                         birthdate: {
-                            validators: {
-                                multivalued: {
-                                    max: 1
-                                }
-                            },
+                            validators: {},
                             displayName: "Birthdate",
-                            values: [],
                             annotations: {
                                 inputType: "html5-date"
                             },
-                            required: false,
-                            multivalued: false,
-                            readOnly: false,
+                            name: "birthdate"
+                        }
+                    }
+                }
+            }}
+        />
+    )
+};
+
+export const WithMoreFieldsPrefilled: Story = {
+    render: () => (
+        <KcPageStory
+            kcContext={{
+                profile: {
+                    attributesByName: {
+                        multiAttribute: {
+                            validators: {},
+                            displayName: "Multi-Attribute Field",
+                            annotations: {},
+                            multivalued: true,
+                            values: ["value 1", "value 2"],
+                            name: "multiAttribute"
+                        },
+                        favouritePet: {
+                            validators: {
+                                options: {
+                                    options: ["Cat", "Dog", "Bird"]
+                                }
+                            },
+                            displayName: "Favourite Pet",
+                            annotations: {
+                                inputType: "select"
+                            },
+                            value: "dog",
+                            name: "favouritePet"
+                        },
+                        age: {
+                            validators: {
+                                integer: {
+                                    min: 0,
+                                    max: 99
+                                }
+                            },
+                            displayName: "Age",
+                            annotations: {
+                                inputType: "html5-number"
+                            },
+                            value: "22",
+                            name: "age"
+                        },
+                        birthdate: {
+                            validators: {},
+                            displayName: "Birthdate",
+                            annotations: {
+                                inputType: "html5-date"
+                            },
+                            value: "2000-01-01",
                             name: "birthdate"
                         }
                     }

--- a/stories/login/pages/LoginUpdateProfile.stories.tsx
+++ b/stories/login/pages/LoginUpdateProfile.stories.tsx
@@ -119,7 +119,7 @@ export const WithMoreFieldsPrefilled: Story = {
                             annotations: {
                                 inputType: "select"
                             },
-                            value: "dog",
+                            value: "Dog",
                             name: "favouritePet"
                         },
                         age: {

--- a/stories/login/pages/LoginUpdateProfile.stories.tsx
+++ b/stories/login/pages/LoginUpdateProfile.stories.tsx
@@ -39,3 +39,44 @@ export const WithProfileError: Story = {
         />
     )
 };
+
+export const WithMoreFields: Story = {
+    render: () => (
+        <KcPageStory
+            kcContext={{
+                profile: {
+                    attributesByName: {
+                        multiAttribute: {
+                            validators: {},
+                            displayName: "Multi-Attribute Field",
+                            annotations: {},
+                            required: false,
+                            multivalued: true,
+                            readOnly: false,
+                            name: "multiAttribute"
+                        },
+                        favouritePet: {
+                            validators: {
+                                options: {
+                                    options: ["Cat", "Dog", "Bird"]
+                                },
+                                multivalued: {
+                                    max: "1"
+                                }
+                            },
+                            displayName: "Favourite Pet",
+                            values: [],
+                            annotations: {
+                                inputType: "select"
+                            },
+                            required: false,
+                            multivalued: false,
+                            readOnly: false,
+                            name: "favouritePet"
+                        }
+                    }
+                }
+            }}
+        />
+    )
+};

--- a/stories/login/pages/LoginUpdateProfile.stories.tsx
+++ b/stories/login/pages/LoginUpdateProfile.stories.tsx
@@ -123,7 +123,7 @@ export const WithGroups: Story = {
             kcContext={{
                 profile: {
                     attributesByName: {
-                        cardId: {
+                        division: {
                             validators: {},
                             displayName: "Division",
                             annotations: {},


### PR DESCRIPTION
Hello guys,
I added some more input types to LoginUpdateProfile.
The values for kcContext are taken from the browser console on a real keycloak instance

Looks like this:
<img width="1705" height="986" alt="image" src="https://github.com/user-attachments/assets/f389280e-ed0c-44b1-b16d-c2bfb58f168c" />


I also added a group.
in my custom theme, this renders correctly:
<img width="512" height="712" alt="image" src="https://github.com/user-attachments/assets/1684c476-d66a-47ed-9ea1-f08402c4e47c" />

For reasons i do not understand, the `GroupLabel` component in `UserProfileFormFields` is not rendered (without error) in this repo, only on my custom theme, even though i didn't change the structure (all the `if`s and stuff still exist like before).
That's the reason I included it here.
If that's a problem, i can remove the sections

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three interactive profile-update demos: a "More Fields" scenario (multi-valued attribute, pet-selection dropdown, constrained numeric input 0–99, and date input), a prefilled variant of that scenario with example values, and a demo showcasing grouped profile attributes with a "user metadata" section for nested/grouped fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->