### PR TITLE
fix(a11y): add missing tab index

### DIFF
--- a/src/login/pages/Login.tsx
+++ b/src/login/pages/Login.tsx
@@ -138,7 +138,7 @@ export default function Login(props: PageProps<Extract<KcContext, { pageId: "log
                                 <label htmlFor="password" className={kcClsx("kcLabelClass")}>
                                     {msg("password")}
                                 </label>
-                                <PasswordWrapper kcClsx={kcClsx} i18n={i18n} passwordInputId="password">
+                                <PasswordWrapper kcClsx={kcClsx} tabIndex={4} i18n={i18n} passwordInputId="password">
                                     <input
                                         tabIndex={3}
                                         id="password"
@@ -239,8 +239,8 @@ export default function Login(props: PageProps<Extract<KcContext, { pageId: "log
     );
 }
 
-function PasswordWrapper(props: { kcClsx: KcClsx; i18n: I18n; passwordInputId: string; children: JSX.Element }) {
-    const { kcClsx, i18n, passwordInputId, children } = props;
+function PasswordWrapper(props: { kcClsx: KcClsx; tabIndex: number; i18n: I18n; passwordInputId: string; children: JSX.Element }) {
+    const { kcClsx, tabIndex, i18n, passwordInputId, children } = props;
 
     const { msgStr } = i18n;
 
@@ -251,6 +251,7 @@ function PasswordWrapper(props: { kcClsx: KcClsx; i18n: I18n; passwordInputId: s
             {children}
             <button
                 type="button"
+                tabIndex={tabIndex}
                 className={kcClsx("kcFormPasswordVisibilityButtonClass")}
                 aria-label={msgStr(isPasswordRevealed ? "hidePassword" : "showPassword")}
                 aria-controls={passwordInputId}


### PR DESCRIPTION
A recent accessibility screening showed a flaw in the tab order on the login screen.
The "show password" button has no `tabindex` set and comes last in the order.

Upstream has this attribute:
https://github.com/keycloak/keycloak/blame/e4e92460f983e09b2a086d17036117c1f2bae175/themes/src/main/resources/theme/base/login/login.ftl#L38

I thought I might as well add it!
The solution is more than 1 line because I thought it would be nicer to have all the `tabIndex` values in the top part of the form, so it's less likely to be missed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard navigation in the login form by ensuring the password visibility toggle is properly included in the tab order.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/keycloakify/keycloakify/pull/1019?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->