### PR TITLE
fix: correctly handle mailto: and tel: URIs

### DIFF
--- a/src/lib/kcSanitize/HtmlPolicyBuilder.ts
+++ b/src/lib/kcSanitize/HtmlPolicyBuilder.ts
@@ -112,6 +112,7 @@ export class HtmlPolicyBuilder {
         this.allowedProtocols.add("http");
         this.allowedProtocols.add("https");
         this.allowedProtocols.add("mailto");
+        this.allowedProtocols.add("tel");
         return this;
     }
 
@@ -251,7 +252,26 @@ export class HtmlPolicyBuilder {
     }
 
     private getAllowedUriRegexp(): RegExp {
-        const protocols = Array.from(this.allowedProtocols).join("|");
-        return new RegExp(`^(?:${protocols})://`, "i");
+        // Protocols like `mailto:` and `tel:` use a `scheme:opaque` form without
+        // the `//` authority, so they must be matched separately from network
+        // protocols such as `http://` and `https://`.
+        const schemeOnlyProtocols = new Set(["mailto", "tel"]);
+        const allowed = Array.from(this.allowedProtocols);
+        const withAuthority = allowed.filter(p => !schemeOnlyProtocols.has(p));
+        const schemeOnly = allowed.filter(p => schemeOnlyProtocols.has(p));
+        const alternatives: string[] = [];
+        if (withAuthority.length) {
+            alternatives.push(`(?:${withAuthority.join("|")})://`);
+        }
+        if (schemeOnly.length) {
+            alternatives.push(`(?:${schemeOnly.join("|")}):`);
+        }
+        if (alternatives.length === 0) {
+            // With no allowed protocols an empty alternation would match the
+            // start of every string, permissively allowing all URIs, so match
+            // nothing instead.
+            return new RegExp("^$");
+        }
+        return new RegExp(`^(?:${alternatives.join("|")})`, "i");
     }
 }


### PR DESCRIPTION
Fixes the handling of `mailto:` URIs, and adds the same handling for `tel:` URIs.

Fixes: #1022


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for telephone links (tel:) in HTML content so clickable phone numbers can initiate calls, alongside existing web (http/https) and email (mailto:) links.
  * Improved link recognition and case-insensitive handling for different link types for more reliable clickable link detection in rendered content.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/keycloakify/keycloakify/pull/1023?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->