### PR TITLE
Fix DEP0190 spawn deprecation warnings introduced in node 24.15

### DIFF
--- a/scripts/shared/startRebuildOnSrcChange.ts
+++ b/scripts/shared/startRebuildOnSrcChange.ts
@@ -13,7 +13,7 @@ export function startRebuildOnSrcChange() {
 
         const dCompleted = new Deferred<void>();
 
-        const child = child_process.spawn("yarn", ["build"], { shell: true });
+        const child = child_process.spawn("yarn build", { shell: true });
 
         child.stdout.on("data", data => process.stdout.write(data));
 

--- a/scripts/start-storybook.ts
+++ b/scripts/start-storybook.ts
@@ -6,7 +6,7 @@ import { run } from "./shared/run";
     run("yarn build");
 
     {
-        const child = child_process.spawn("npx", ["start-storybook", "-p", "6006"], {
+        const child = child_process.spawn("npx start-storybook -p 6006", {
             shell: true
         });
 

--- a/src/bin/start-keycloak/appBuild.ts
+++ b/src/bin/start-keycloak/appBuild.ts
@@ -152,7 +152,7 @@ export async function appBuild(params: {
 
         console.log(chalk.blue("$ npx vite build"));
 
-        const child = child_process.spawn("npx", ["vite", "build"], {
+        const child = child_process.spawn("npx vite build", {
             cwd: buildContext.projectDirPath,
             shell: true
         });

--- a/src/bin/start-keycloak/keycloakifyBuild.ts
+++ b/src/bin/start-keycloak/keycloakifyBuild.ts
@@ -22,7 +22,7 @@ export async function keycloakifyBuild(params: {
 
     console.log(chalk.blue("$ npx keycloakify build"));
 
-    const child = child_process.spawn("npx", ["keycloakify", "build"], {
+    const child = child_process.spawn("npx keycloakify build", {
         cwd: buildContext.projectDirPath,
         env: {
             ...process.env,

--- a/src/bin/start-keycloak/realmConfig/dumpContainerConfig.ts
+++ b/src/bin/start-keycloak/realmConfig/dumpContainerConfig.ts
@@ -52,27 +52,24 @@ export async function dumpContainerConfig(params: {
 
     {
         const dCompleted = new Deferred<void>();
+        const dockerArguments = [
+            ...["exec", CONTAINER_NAME],
+            ...["/opt/keycloak/bin/kc.sh", "export"],
+            ...["--dir", "/tmp"],
+            ...["--realm", realmName],
+            ...["--users", "realm_file"],
+            ...(!doesUseLockedH2Database
+                ? []
+                : [
+                        ...["--db", "dev-file"],
+                        ...[
+                            "--db-url",
+                            '"jdbc:h2:file:/tmp/h2/keycloakdb;NON_KEYWORDS=VALUE"'
+                        ]
+                    ])
+        ];
 
-        const child = child_process.spawn(
-            "docker",
-            [
-                ...["exec", CONTAINER_NAME],
-                ...["/opt/keycloak/bin/kc.sh", "export"],
-                ...["--dir", "/tmp"],
-                ...["--realm", realmName],
-                ...["--users", "realm_file"],
-                ...(!doesUseLockedH2Database
-                    ? []
-                    : [
-                          ...["--db", "dev-file"],
-                          ...[
-                              "--db-url",
-                              '"jdbc:h2:file:/tmp/h2/keycloakdb;NON_KEYWORDS=VALUE"'
-                          ]
-                      ])
-            ],
-            { shell: true }
-        );
+        const child = child_process.spawn("docker " + dockerArguments.join(" "), { shell: true });
 
         let output = "";
 

--- a/src/bin/start-keycloak/start-keycloak.ts
+++ b/src/bin/start-keycloak/start-keycloak.ts
@@ -621,8 +621,8 @@ export async function command(params: {
     );
 
     const child = child_process.spawn(
-        "docker",
-        ["run", ...dockerRunArgs.map(line => line.split(SPACE_PLACEHOLDER)).flat()],
+        "docker run " +
+        dockerRunArgs.map(line => line.split(SPACE_PLACEHOLDER)).flat().join(" "),
         { shell: true }
     );
 

--- a/src/bin/start-keycloak/startViteDevServer.ts
+++ b/src/bin/start-keycloak/startViteDevServer.ts
@@ -18,7 +18,7 @@ export function startViteDevServer(params: {
 
     console.log(chalk.blue(`$ npx vite dev`));
 
-    const child = child_process.spawn("npx", ["vite", "dev"], {
+    const child = child_process.spawn("npx vite dev", {
         cwd: buildContext.projectDirPath,
         env: {
             ...process.env,

--- a/src/bin/tools/npmInstall.ts
+++ b/src/bin/tools/npmInstall.ts
@@ -98,10 +98,10 @@ async function runPackageManagerInstall(params: {
     const { packageManagerBinName, cwd } = params;
 
     const dCompleted = new Deferred<void>();
+    const packageManagerArguments = ["install", ...(packageManagerBinName !== "npm" ? [] : ["--force"])];
 
     const child = child_process.spawn(
-        packageManagerBinName,
-        ["install", ...(packageManagerBinName !== "npm" ? [] : ["--force"])],
+        packageManagerBinName + " " + packageManagerArguments.join(" "),
         {
             cwd,
             env: process.env,


### PR DESCRIPTION
Node introduced these deprecation warnings when passing arguments seperately into a spawn combined with `{ shell: true }`:
https://nodejs.org/api/deprecations.html#dep0190-passing-args-to-nodechild_process-execfilespawn-with-shell-option

This change merges the command and arguments into a single param to omit the deprecation warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored internal build and development server initialization to use simplified process spawning approach across multiple development scripts.

**Note:** These are infrastructure-level changes with no visible impact to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->