### PR TITLE
fix: WebAuthnError execution value

### DIFF
--- a/src/login/pages/WebauthnError.tsx
+++ b/src/login/pages/WebauthnError.tsx
@@ -15,6 +15,8 @@ export default function WebauthnError(props: PageProps<Extract<KcContext, { page
         classes
     });
 
+    const execution = getExecutionFromLoginAction(url.loginAction);
+
     return (
         <Template
             kcContext={kcContext}
@@ -34,7 +36,7 @@ export default function WebauthnError(props: PageProps<Extract<KcContext, { page
                     // @ts-expect-error: Trusted Keycloak's code
                     document.getElementById("isSetRetry").value = "retry";
                     // @ts-expect-error: Trusted Keycloak's code
-                    document.getElementById("executionValue").value = "${execution}";
+                    document.getElementById("executionValue").value = execution;
                     // @ts-expect-error: Trusted Keycloak's code
                     document.getElementById("kc-error-credential-form").requestSubmit();
                 }}
@@ -59,4 +61,10 @@ export default function WebauthnError(props: PageProps<Extract<KcContext, { page
             )}
         </Template>
     );
+}
+
+function getExecutionFromLoginAction(loginAction: string): string {
+    return new URL(loginAction, window.location.origin)
+        .searchParams
+        .get("execution") ?? "";
 }


### PR DESCRIPTION
Fixes #952 

replace the literal "${execution}":
https://github.com/keycloakify/keycloakify/blob/831d83b3fe75e08cab1f6b09d3b26a93b9342b6f/src/login/pages/WebauthnError.tsx#L37

with the execution value obtained from `url.loginAction`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webauthn error handling to dynamically retrieve execution context from the login action, ensuring the "try again" option works correctly with the proper authentication flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->