### PR TITLE
Exclude storybook base stories maybe

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "keycloakify",
-    "version": "11.15.7",
+    "version": "11.15.8-rc.3",
     "description": "Framework to create custom Keycloak UIs",
     "repository": {
         "type": "git",

--- a/src/bin/initialize-login-theme.ts
+++ b/src/bin/initialize-login-theme.ts
@@ -1,5 +1,5 @@
 import { maybeDelegateCommandToCustomHandler } from "./shared/customHandler_delegate";
-import { dirname as pathDirname, join as pathJoin } from "path";
+import { dirname as pathDirname, join as pathJoin, sep as pathSep } from "path";
 import type { BuildContext } from "./shared/buildContext";
 import * as fs from "fs/promises";
 import { assert, is, type Equals } from "tsafe/assert";
@@ -12,6 +12,7 @@ import { z } from "zod";
 import chalk from "chalk";
 import cliSelect from "cli-select";
 import { existsAsync } from "./tools/fs.existsAsync";
+import { getExtensionModuleMetas } from "./sync-extensions/extensionModuleMeta";
 
 export async function command(params: { buildContext: BuildContext }) {
     const { buildContext } = params;
@@ -183,6 +184,23 @@ export async function command(params: { buildContext: BuildContext }) {
         }
 
         const moduleName = "@keycloakify/login-ui-storybook";
+
+        const extensionModuleMetas = await getExtensionModuleMetas({ buildContext });
+
+        const hasLoginStoriesProvidedFromOtherModule =
+            extensionModuleMetas.find(
+                meta =>
+                    meta.files.find(
+                        file =>
+                            file.fileRelativePath.startsWith(
+                                `login${pathSep}pages${pathSep}`
+                            ) && file.copyableFilePath.endsWith(".stories.tsx")
+                    ) !== undefined
+            ) !== undefined;
+
+        if (hasLoginStoriesProvidedFromOtherModule) {
+            break install_stories;
+        }
 
         const latestVersion = getModuleLatestVersion({ moduleName });
 

--- a/src/bin/sync-extensions/extensionModuleMeta.ts
+++ b/src/bin/sync-extensions/extensionModuleMeta.ts
@@ -319,7 +319,7 @@ export async function getExtensionModuleMetas(params: {
                                 }
                             }
 
-                            fsPr.writeFile(copyableFilePath, sourceCode);
+                            await fsPr.writeFile(copyableFilePath, sourceCode);
 
                             files.push({
                                 isPublic,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Login theme initialization now detects existing login stories and will skip installing duplicate storybook assets.

* **Bug Fixes**
  * Ensured extension metadata cache writes complete before proceeding to avoid synchronization races.

* **Chores**
  * Version bumped to 11.15.8-rc.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->