### PR TITLE
fix: add missing totp username property

### DIFF
--- a/src/account/KcContext/KcContext.ts
+++ b/src/account/KcContext/KcContext.ts
@@ -184,6 +184,7 @@ export declare namespace KcContext {
             totpSecretQrCode: string;
             manualUrl: string;
             totpSecret: string;
+            username: string;
             otpCredentials: { id: string; userLabel: string }[];
         };
         mode?: "qr" | "manual" | undefined | null;

--- a/src/account/KcContext/kcContextMocks.ts
+++ b/src/account/KcContext/kcContextMocks.ts
@@ -173,7 +173,8 @@ export const kcContextMocks: KcContext[] = [
                 type: "totp",
                 period: 30,
                 getAlgorithmKey: () => "SHA1"
-            }
+            },
+            username: "alice@example.com"
         },
         mode: "qr",
         isAppInitiatedAction: false,

--- a/src/login/KcContext/KcContext.ts
+++ b/src/login/KcContext/KcContext.ts
@@ -489,6 +489,7 @@ export declare namespace KcContext {
             totpSecretQrCode: string;
             manualUrl: string;
             totpSecret: string;
+            username: string;
             otpCredentials: { id: string; userLabel: string }[];
         };
     };

--- a/src/login/KcContext/kcContextMocks.ts
+++ b/src/login/KcContext/kcContextMocks.ts
@@ -446,7 +446,8 @@ export const kcContextMocks = [
                 type: "totp",
                 period: 30,
                 getAlgorithmKey: () => "SHA1"
-            }
+            },
+            username: "alice@example.com"
         }
     }),
     id<KcContext.LogoutConfirm>({


### PR DESCRIPTION
A quick fix to add the missing `username` property to the TypeScript definitions of the `login-config-totp` page

This is provided by Keycloak [here](https://github.com/keycloak/keycloak/blob/main/services/src/main/java/org/keycloak/forms/login/freemarker/model/TotpBean.java#L121-L123), I suspect it was missed because the current FTL template doesn't make use of it.

I would like this property present so I can build a `otpauth://` in addition to the QR code without having to use ts-ignore. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced TOTP authentication flows to include username support across account and login contexts, improving credential handling during two-factor authentication setup and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->