### PR TITLE
fix(account): don't drop application.client from the kcContext

### DIFF
--- a/src/bin/keycloakify/generateFtl/kcContextDeclarationTemplate.ftl
+++ b/src/bin/keycloakify/generateFtl/kcContextDeclarationTemplate.ftl
@@ -240,6 +240,19 @@ function decodeHtmlEntities(htmlStr){
                 <#if stringified?starts_with("org.keycloak.models.RequiredActionProviderModel") >
                     <#break>
                 </#if>
+                <#--
+                    On the applications.ftl page of the multi page account theme, each
+                    application.client is a ClientModel. It's not a Keycloak internal leaking
+                    into the kcContext, the page is meant to expose it.
+                    See: https://github.com/keycloakify/keycloakify/issues/1040
+                -->
+                <#if
+                    xKeycloakify.themeType == "account" &&
+                    xKeycloakify.pageId == "applications.ftl" &&
+                    areSamePath(path, [ "applications", "applications", "*", "client" ])
+                >
+                    <#break>
+                </#if>
                 <#list ["models", "services", "authentication", "quarkus.runtime", "transaction", "connections", "utils.ClosingStream"] as namespacePortion>
                     <#if stringified?starts_with("org.keycloak." + namespacePortion)>
                         <#return abort>


### PR DESCRIPTION
On the `applications.ftl` page of the Multi-Page account theme, every `application.client` is a `ClientModel`, so the `org.keycloak.models` blocklist dropped it. The stock `Applications` page then throws on `application.client.clientId` and renders nothing.

Adds an exception scoped to that exact path, next to the existing `OTPPolicy` one. Verified end to end on Keycloak 26.7.0.

Fixes #1040

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where application data could fail to load on the applications page when it included client details.
  * Improved serialization of application information for more reliable page rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->