### PR TITLE
fix: WebAuthn registration in latest Keycloak

### DIFF
--- a/src/login/KcContext/KcContext.ts
+++ b/src/login/KcContext/KcContext.ts
@@ -431,7 +431,7 @@ export declare namespace KcContext {
         attestationConveyancePreference: string;
         authenticatorAttachment: string;
         requireResidentKey: string;
-        residentKey: string;
+        residentKey?: string;
         userVerificationRequirement: string;
         createTimeout: number | string;
         excludeCredentialIds: string;

--- a/src/login/KcContext/KcContext.ts
+++ b/src/login/KcContext/KcContext.ts
@@ -431,6 +431,7 @@ export declare namespace KcContext {
         attestationConveyancePreference: string;
         authenticatorAttachment: string;
         requireResidentKey: string;
+        residentKey: string;
         userVerificationRequirement: string;
         createTimeout: number | string;
         excludeCredentialIds: string;

--- a/src/login/KcContext/kcContextMocks.ts
+++ b/src/login/KcContext/kcContextMocks.ts
@@ -540,6 +540,7 @@ export const kcContextMocks = [
         attestationConveyancePreference: "direct",
         authenticatorAttachment: "platform",
         requireResidentKey: "required",
+        residentKey: "required",
         userVerificationRequirement: "preferred",
         createTimeout: 60000,
         excludeCredentialIds: "credId123,credId456",

--- a/src/login/pages/WebauthnRegister.tsx
+++ b/src/login/pages/WebauthnRegister.tsx
@@ -41,6 +41,7 @@ export default function WebauthnRegister(props: PageProps<Extract<KcContext, { p
                     <input type="hidden" id="publicKeyCredentialId" name="publicKeyCredentialId" />
                     <input type="hidden" id="authenticatorLabel" name="authenticatorLabel" />
                     <input type="hidden" id="transports" name="transports" />
+                    <input type="hidden" id="authenticatorAttachment" name="authenticatorAttachment" />
                     <input type="hidden" id="error" name="error" />
                     <LogoutOtherSessions kcClsx={kcClsx} i18n={i18n} />
                 </div>

--- a/src/login/pages/WebauthnRegister.useScript.tsx
+++ b/src/login/pages/WebauthnRegister.useScript.tsx
@@ -17,6 +17,7 @@ type KcContextLike = {
     attestationConveyancePreference: string;
     authenticatorAttachment: string;
     requireResidentKey: string;
+    residentKey: string;
     userVerificationRequirement: string;
     createTimeout: number | string;
     excludeCredentialIds: string;
@@ -44,6 +45,7 @@ export function useScript(params: { authButtonId: string; kcContext: KcContextLi
         attestationConveyancePreference,
         authenticatorAttachment,
         requireResidentKey,
+        residentKey,
         userVerificationRequirement,
         createTimeout,
         excludeCredentialIds
@@ -70,6 +72,7 @@ export function useScript(params: { authButtonId: string; kcContext: KcContextLi
                             attestationConveyancePreference : ${JSON.stringify(attestationConveyancePreference)},
                             authenticatorAttachment : ${JSON.stringify(authenticatorAttachment)},
                             requireResidentKey : ${JSON.stringify(requireResidentKey)},
+                            residentKey : ${JSON.stringify(residentKey)},
                             userVerificationRequirement : ${JSON.stringify(userVerificationRequirement)},
                             createTimeout : ${createTimeout},
                             excludeCredentialIds : ${JSON.stringify(excludeCredentialIds)},

--- a/src/login/pages/WebauthnRegister.useScript.tsx
+++ b/src/login/pages/WebauthnRegister.useScript.tsx
@@ -17,7 +17,7 @@ type KcContextLike = {
     attestationConveyancePreference: string;
     authenticatorAttachment: string;
     requireResidentKey: string;
-    residentKey: string;
+    residentKey?: string;
     userVerificationRequirement: string;
     createTimeout: number | string;
     excludeCredentialIds: string;


### PR DESCRIPTION
I found two issues while running recent Keycloak with WebAuthn (login-ui):
- registerByWebAuthn() ignored PublicKeyCredential.authenticatorAttachment, so the registration request didn't include it.
- Only legacy requireResidentKey was handled in authenticatorSelection, so the new setting residentKey was ignored.

This is the companion fix for keycloakify/login-ui.

It also fixes https://github.com/keycloakify/keycloakify/issues/1050.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Improved WebAuthn registration by honoring the configured resident key requirement.
  * Registration requests now include the authenticator attachment setting.
  * WebAuthn registration configuration is consistently carried through the registration flow.
* **Bug Fixes**
  * Fixed inconsistencies between registration settings, form submissions, and WebAuthn requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->